### PR TITLE
ci: add dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    versioning-strategy: increase
     groups:
       python-dev:
         dependency-type: development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-dev:
+        dependency-type: development
+      python-prod:
+        dependency-type: production
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly version-update schedules for **pip** (split into `python-prod` / `python-dev` groups) and **github-actions** (single `actions` group), each capped at 5 open PRs.
- Complements the security-updates Dependabot already runs — this only adds non-security version bumps so pinned action SHAs and `pyproject.toml` deps don't quietly drift.

## Why
Repo currently has Dependabot security updates enabled but no version-update config. Without it:
- Pinned action SHAs in [.github/workflows/](.github/workflows/) age silently between security advisories.
- Non-security pip upgrades (e.g. `pydantic`, `lark`, dev tools) require manual tracking.

Grouped PRs keep the noise low — expect ~1–3 PRs/week instead of one per package.

## Test plan
- [ ] After merge, confirm Dependabot runs on the next weekly schedule and opens grouped update PRs (or none, if everything is current).
- [ ] Spot-check the first action-bump PR retains commit-SHA pinning (`uses: org/action@<sha> # vX`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)