### PR TITLE
feat: plugin signature registry for unknown-plugin lineage (PR-D of v0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ The suite covers the documented features end-to-end and a corpus of
 intentionally tricky fixtures (escaped quotes, regex containing `#`, nested
 interpolation, drop semantics, malformed parsers, etc.). See
 [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the parser frontend, native
-acceleration build/runtime flags, and fixture inventory.
+acceleration build/runtime flags, and fixture inventory. To teach the
+analyzer about custom (org-specific) plugins via a small TOML file, see
+[plugin-signatures.md](docs/plugin-signatures.md).
 
 ## References
 

--- a/docs/plugin-signatures.md
+++ b/docs/plugin-signatures.md
@@ -1,0 +1,198 @@
+# Plugin signature registry
+
+Static analysis of a SecOps/Chronicle parser is grounded by a fixed set
+of built-in plugin handlers (`grok`, `mutate`, `date`, `kv`, `json`,
+`csv`, `dissect`, etc.). Anything outside that set — typically
+org-specific custom enrichers, lookup plugins, or vendor-shipped
+filters — falls through to the `unsupported_plugin` taint path: the
+plugin's destinations are marked `unresolved` with a hard taint, and
+queries against those fields return tainted lineage.
+
+The plugin signature registry lets you teach the analyzer about custom
+plugins via a small declarative TOML file. A registered signature
+routes the plugin through a generic-but-sound handler that reads
+declared `source_keys` and `dest_keys` from the plugin's config and
+emits `signature_dispatched` lineage attributing the destinations back
+to the resolved sources. The `unsupported_plugin` taint goes away;
+you get derivable lineage instead.
+
+## When to register a signature
+
+- You have an internal plugin (`acme_geo_enrich`, `corp_threat_lookup`,
+  etc.) whose source/destination fields you know.
+- A vendor plugin's source/destination shape is documented and stable.
+- A community plugin from elsewhere in the Logstash ecosystem behaves
+  like one of the analyzer's built-in semantic classes
+  (`extractor` / `enricher` / `transform` / `mutate_like` / `passthrough`).
+
+If you don't know the plugin's shape — or if the plugin's behavior
+depends on runtime data the analyzer can't observe — leave it
+unsigned. The `unsupported_plugin` taint is the safe default.
+
+## File format
+
+Each top-level table is a `PluginSignature`. The table key supplies
+the default `name` if the table omits one, so the simplest form is:
+
+```toml
+[acme_geo_enrich]
+semantic_class = "enricher"
+source_keys = ["source"]
+dest_keys = ["target"]
+```
+
+Keys are validated by pydantic with `extra = "forbid"`. Typos in
+`semantic_class`, `lineage_status`, or `taint_hint` raise a loud error
+at load time so you discover them before the analyzer silently
+degrades.
+
+### Schema
+
+| Key                | Type                                                    | Default     | Notes                                                                              |
+|--------------------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------------|
+| `name`             | string                                                  | table key   | Plugin name as it appears in the parser (`acme_geo_enrich { ... }`).               |
+| `semantic_class`   | `extractor` / `enricher` / `transform` / `mutate_like` / `passthrough` | required | Coarse category; see [Semantic classes](#semantic-classes) below.                   |
+| `source_keys`      | list of strings                                         | `[]`        | Config keys whose values name source fields read by the plugin.                    |
+| `dest_keys`        | list of strings                                         | `[]`        | Config keys whose values name destination fields written by the plugin.            |
+| `dest_value_kind`  | `scalar` / `map` / `list`                               | `scalar`    | Shape of the value at each `dest_keys` entry. Maps treat keys as destinations.     |
+| `in_place`         | bool                                                    | `false`     | Plugin mutates its source in place (advisory; reserved for future use).            |
+| `lineage_status`   | `exact` / `derived` / `dynamic` / `conditional`         | `derived`   | Status assigned to emitted lineage. `conditional` is auto-applied under branches.  |
+| `taint_hint`       | `none` / `derived` / `dynamic`                          | `derived`   | If non-`none`, attaches `signature_dispatched_<hint>` taint to each destination.   |
+
+## Semantic classes
+
+The `semantic_class` field is a coarse signal about *how* the plugin
+relates to its inputs and outputs. v0.2 doesn't yet branch behavior
+on it — every signature dispatches through the same generic handler —
+but reviewers, tooling, and future PRs will use the class to decide
+when finer-grained handling is appropriate.
+
+- **`extractor`** — pulls structured fields out of an opaque blob.
+  Examples: a custom JSON-shaped log decoder. `source_keys` should
+  point at the raw blob field; `dest_keys` at the new fields produced.
+- **`enricher`** — looks up additional facts about an existing field
+  and writes derived data alongside it. Examples: GeoIP, threat
+  intelligence, asset enrichment. `source_keys` is the input lookup
+  key; `dest_keys` is where the lookup result lands.
+- **`transform`** — reshapes a field in place or to a new field
+  without external lookups. Examples: custom string normalization,
+  hashing.
+- **`mutate_like`** — behaves like Logstash's built-in `mutate`:
+  destinations are usually a `replace` / `add_field` style map.
+  Set `dest_value_kind = "map"` for these.
+- **`passthrough`** — a no-op-from-the-analyzer's-perspective plugin
+  that the user wants to silence. `lineage_status = "exact"` is common.
+
+## Examples
+
+### Enricher (single source → single destination)
+
+```toml
+[acme_geo_enrich]
+semantic_class = "enricher"
+source_keys = ["source"]
+dest_keys = ["target"]
+lineage_status = "derived"
+taint_hint = "derived"
+```
+
+Use for a GeoIP-style plugin invoked as
+`acme_geo_enrich { source => "client_ip" target => "principal.location.country" }`.
+The destination's lineage will attribute back to `client_ip` with a
+`signature_dispatched_derived` taint indicating the value was
+synthesized via an unsigned plugin.
+
+### Mutate-like (map of destinations → sources)
+
+```toml
+[corp_field_remap]
+semantic_class = "mutate_like"
+source_keys = []
+dest_keys = ["replace"]
+dest_value_kind = "map"
+lineage_status = "exact"
+taint_hint = "none"
+```
+
+Use for a plugin that takes a `replace => { dest => source, ... }`
+map similar to Logstash's built-in `mutate { replace => ... }`.
+Destinations come from the map keys; the values' source-field
+expressions feed the upstream-source attribution.
+
+### Passthrough (analyzer should ignore)
+
+```toml
+[debug_only_logger]
+semantic_class = "passthrough"
+source_keys = []
+dest_keys = []
+taint_hint = "none"
+```
+
+Use for a development-time-only logger or any plugin whose effect on
+the data flow is nil.
+
+## Loading signatures
+
+### CLI
+
+```sh
+parser-lineage-analyzer my_parser.cbn target.field \
+  --plugin-signatures team-defaults.toml \
+  --plugin-signatures-dir ./signatures
+```
+
+Both flags are repeatable. Directories load every `*.toml` file
+within them in sorted-name order; individual `--plugin-signatures`
+files load after directories. Last-write-wins on duplicate `name`
+across the entire load order.
+
+### Programmatic
+
+```python
+from pathlib import Path
+from parser_lineage_analyzer import ReverseParser
+from parser_lineage_analyzer._plugin_signatures import PluginSignatureRegistry
+
+registry = PluginSignatureRegistry.from_paths(
+    files=[Path("signatures/override.toml")],
+    directories=[Path("signatures/defaults")],
+)
+parser = ReverseParser(open("my_parser.cbn").read(), plugin_signatures=registry)
+parser.analyze()
+```
+
+## Soundness contract
+
+A signature is a *shape* declaration, not a behavioral spec. The
+generic handler emits `signature_dispatched` lineage for every
+declared destination, attributing it to the resolved sources of the
+declared `source_keys`. It does NOT attempt to model the plugin's
+real semantics — if the plugin internally transforms or filters the
+data in a way that affects which UDM field actually gets written,
+the attribution may be approximate.
+
+Two safety nets:
+
+1. **Lookup miss is sound.** When no signature matches the plugin
+   name, the analyzer falls through to the existing
+   `unsupported_plugin` taint path. Pre-F3 behavior is preserved
+   byte-for-byte.
+
+2. **Validation errors are loud.** Pydantic `extra = "forbid"` plus
+   `Literal[...]` enums on the type-fields catch typos at TOML load
+   time. A misspelled `semantic_class` raises `ValueError` rather
+   than silently registering a partial signature.
+
+## Bundled signatures
+
+v0.2 ships **no bundled signatures**. The `parser_lineage_analyzer/
+plugin_signatures/` directory is intentionally empty; the loader
+consults it so future bundled additions need no code change.
+
+The deliberate choice is to avoid silently shipping signatures that
+a user might rely on without auditing — a wrong signature for a
+real plugin can produce misleading lineage, which is worse than no
+lineage. Examples in this document are pedagogical only; copy what
+fits your environment, audit it, and load it via your own
+`--plugin-signatures` files.

--- a/docs/plugin-signatures.md
+++ b/docs/plugin-signatures.md
@@ -116,8 +116,29 @@ taint_hint = "none"
 
 Use for a plugin that takes a `replace => { dest => source, ... }`
 map similar to Logstash's built-in `mutate { replace => ... }`.
-Destinations come from the map keys; the values' source-field
-expressions feed the upstream-source attribution.
+Destinations come from the map keys; **each destination's lineage is
+attributed to the plugin-scope `source_keys` plus the pair's specific
+RHS source** — so `dst1 => "%{x}"` and `dst2 => "%{y}"` produce
+distinct upstream attributions, not the union of `x` and `y`.
+
+### Fan-out enricher (single source → list of destinations)
+
+```toml
+[fanout_enricher]
+semantic_class = "enricher"
+source_keys = ["source"]
+dest_keys = ["targets"]
+dest_value_kind = "list"
+lineage_status = "derived"
+taint_hint = "derived"
+```
+
+Use for a plugin invoked as
+`fanout_enricher { source => "client_ip" targets => ["principal.ip", "src.geo.country"] }`.
+Each entry in the list becomes a destination, attributed back to the
+plugin-scope `source_keys`. **Without `dest_value_kind = "list"`**
+the handler treats a non-pairs list as a misshapen map and silently
+ignores it — explicit declaration disambiguates intent.
 
 ### Passthrough (analyzer should ignore)
 

--- a/parser_lineage_analyzer/_analysis_executor.py
+++ b/parser_lineage_analyzer/_analysis_executor.py
@@ -7,6 +7,7 @@ from ._analysis_flow import FlowExecutorMixin
 from ._analysis_resolution import ResolutionMixin
 from ._plugins_extractors import ExtractorPluginMixin
 from ._plugins_mutate import MutatePluginMixin
+from ._plugins_signature import SignaturePluginMixin
 from ._plugins_transforms import TransformPluginMixin
 
 _EXECUTOR_COMPONENTS = (
@@ -16,6 +17,7 @@ _EXECUTOR_COMPONENTS = (
     ExtractorPluginMixin,
     TransformPluginMixin,
     MutatePluginMixin,
+    SignaturePluginMixin,
 )
 
 
@@ -41,5 +43,6 @@ class AnalysisExecutor(
     ExtractorPluginMixin,
     TransformPluginMixin,
     MutatePluginMixin,
+    SignaturePluginMixin,
 ):
     """Concrete execution context used by ``ReverseParser``."""

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -1405,6 +1405,27 @@ class FlowExecutorMixin:
                 parser_location=loc,
             )
         else:
+            # F3 (PR-D): consult the plugin signature registry before falling
+            # through to the unsupported-plugin taint path. ``self.plugin_signatures``
+            # is set by ``ReverseParser.__init__`` (None preserves pre-F3
+            # behavior). A registered signature routes to a generic handler
+            # (provided by ``SignaturePluginMixin``, also mixed into
+            # :class:`AnalysisExecutor`) that emits ``signature_dispatched``
+            # lineage; an unregistered name still produces the
+            # ``unsupported_plugin`` taint.
+            sig = None
+            registry = getattr(self, "plugin_signatures", None)
+            if registry is not None:
+                sig = registry.lookup(stmt.name)
+            if sig is not None:
+                # ``_exec_signature_dispatched`` is contributed by
+                # ``SignaturePluginMixin`` at composition time; mypy can't
+                # see across the sibling-mixin boundary in this file so
+                # the call site is annotated rather than forcing a
+                # circular import on a Protocol.
+                self._exec_signature_dispatched(stmt, state, conditions, sig)  # type: ignore[attr-defined]
+                return
+
             warning = unsupported_plugin(stmt.line, stmt.name)
             state.add_unsupported(
                 warning,

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -1424,6 +1424,12 @@ class FlowExecutorMixin:
                 # the call site is annotated rather than forcing a
                 # circular import on a Protocol.
                 self._exec_signature_dispatched(stmt, state, conditions, sig)  # type: ignore[attr-defined]
+                # Built-in plugins (line 1371 above) call ``_handle_on_error``
+                # after dispatch so a trailing ``on_error { ... }`` block runs
+                # symbolically. Custom plugins routed via the signature
+                # registry must have the same treatment — without this call,
+                # the analyzer silently drops the on_error fallback.
+                cast(_FlowContext, self)._handle_on_error(stmt, state, conditions)
                 return
 
             warning = unsupported_plugin(stmt.line, stmt.name)

--- a/parser_lineage_analyzer/_plugin_config_models.py
+++ b/parser_lineage_analyzer/_plugin_config_models.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
@@ -71,6 +73,30 @@ class UrlDecodePluginConfig(_PluginConfig):
     field: str | None = None
     fields: list[object] | str | None = None
     target: str | None = None
+
+
+# F3 (PR-D): plugin signature registry — see parser_lineage_analyzer/
+# _plugin_signatures.py for the loader and dispatch wiring. Without a
+# matching signature, an unknown plugin invocation falls through to the
+# ``unsupported_plugin`` taint path. With one, the dispatcher routes to a
+# generic handler that reads ``source_keys`` / ``dest_keys`` from the
+# plugin's config and produces signature-dispatched lineage tagged with
+# the declared ``lineage_status`` and ``taint_hint``.
+#
+# ``extra="forbid"`` keeps typos in semantic_class / lineage_status /
+# taint_hint loud — they surface at TOML load time as
+# ``ValidationError`` rather than silently degrading to UNKNOWN.
+class PluginSignature(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    semantic_class: Literal["extractor", "enricher", "transform", "mutate_like", "passthrough"]
+    source_keys: list[str] = Field(default_factory=list)
+    dest_keys: list[str] = Field(default_factory=list)
+    dest_value_kind: Literal["scalar", "map", "list"] = "scalar"
+    in_place: bool = False
+    lineage_status: Literal["exact", "derived", "dynamic", "conditional"] = "derived"
+    taint_hint: Literal["none", "derived", "dynamic"] = "derived"
 
 
 def compact_validation_error(exc: ValidationError) -> str:

--- a/parser_lineage_analyzer/_plugin_config_models.py
+++ b/parser_lineage_analyzer/_plugin_config_models.py
@@ -83,12 +83,13 @@ class UrlDecodePluginConfig(_PluginConfig):
 # plugin's config and produces signature-dispatched lineage tagged with
 # the declared ``lineage_status`` and ``taint_hint``.
 #
-# ``extra="forbid"`` keeps typos in semantic_class / lineage_status /
-# taint_hint loud — they surface at TOML load time as
-# ``ValidationError`` rather than silently degrading to UNKNOWN.
-class PluginSignature(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+# Inherits ``_PluginConfig`` for parity with sibling models — that
+# combines ``extra="forbid"`` (typos in semantic_class /
+# lineage_status / taint_hint surface as loud ``ValidationError`` at
+# TOML load time rather than silently degrading to UNKNOWN) with
+# ``strict=True`` (no implicit type coercion on ``in_place: bool``,
+# etc.).
+class PluginSignature(_PluginConfig):
     name: str
     semantic_class: Literal["extractor", "enricher", "transform", "mutate_like", "passthrough"]
     source_keys: list[str] = Field(default_factory=list)

--- a/parser_lineage_analyzer/_plugin_signatures.py
+++ b/parser_lineage_analyzer/_plugin_signatures.py
@@ -1,0 +1,183 @@
+"""Plugin signature registry (F3, PR-D).
+
+A :class:`PluginSignatureRegistry` is a thin wrapper over
+``dict[str, PluginSignature]`` that lets users teach the analyzer about
+custom (e.g. org-specific) plugins via declarative TOML files. Without
+a registered signature, an unknown plugin hits the
+``_taint_unsupported_plugin_destinations`` path in ``_analysis_flow.py``
+and produces a hard ``unsupported_plugin`` taint. With one, the
+dispatcher in ``_analysis_flow.FlowExecutorMixin._exec_plugin`` hands
+off to ``_plugins_signature.SignaturePluginMixin._exec_signature_dispatched``,
+which produces generic but sound lineage that respects the plugin's
+declared source/destination shape.
+
+TOML format
+-----------
+
+Each top-level table maps to a :class:`PluginSignature`. The table key
+is used as the default ``name`` if the table omits one, so users can
+write::
+
+    [example_extractor]
+    semantic_class = "extractor"
+    source_keys = ["source"]
+    dest_keys = ["target"]
+    lineage_status = "derived"
+    taint_hint = "derived"
+
+See ``docs/plugin-signatures.md`` for the full schema and per-class
+examples.
+
+Soundness
+---------
+
+Lookup miss MUST fall through to the existing ``unsupported_plugin``
+taint path — the dispatcher checks for ``None`` explicitly. Validation
+errors from a malformed TOML table raise ``ValueError`` at load time
+rather than silently registering a partial signature.
+
+Determinism
+-----------
+
+Tables within a TOML file load in sorted-key order. Files within a
+directory load in sorted-name order. Inputs to ``from_paths`` (and
+``--plugin-signatures-dir`` / ``--plugin-signatures``) merge in argv
+order with last-write-wins.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import cast
+
+from pydantic import ValidationError
+
+from ._plugin_config_models import PluginSignature, compact_validation_error
+
+# Standard 3.10-compatible tomllib idiom. ``tomli`` is a runtime dep on
+# 3.10 (see pyproject.toml); 3.11+ ships ``tomllib`` in the stdlib.
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised on 3.10 only
+    import tomli as tomllib
+
+
+class PluginSignatureRegistry:
+    """Mapping of plugin name → :class:`PluginSignature`."""
+
+    __slots__ = ("_signatures",)
+
+    def __init__(self, signatures: Mapping[str, PluginSignature] | None = None) -> None:
+        self._signatures: dict[str, PluginSignature] = dict(signatures) if signatures else {}
+
+    def register(self, sig: PluginSignature) -> None:
+        """Insert or overwrite a single signature keyed by ``sig.name``."""
+        self._signatures[sig.name] = sig
+
+    def lookup(self, name: str) -> PluginSignature | None:
+        """Return the signature for ``name`` or ``None`` if unregistered."""
+        return self._signatures.get(name)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._signatures
+
+    def __len__(self) -> int:
+        return len(self._signatures)
+
+    def names(self) -> list[str]:
+        """Return registered plugin names sorted for determinism."""
+        return sorted(self._signatures)
+
+    def load_toml(self, path: Path) -> None:
+        """Load signatures from a single TOML file.
+
+        Each top-level table becomes a :class:`PluginSignature` keyed by
+        its ``name`` field (defaulting to the table key if omitted).
+        Tables that fail validation raise ``ValueError`` with a compact
+        diagnostic so the user sees the bad table immediately.
+        """
+        path = Path(path)
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise ValueError(f"{path}: expected a TOML mapping, got {type(data).__name__}")
+        # Sort table keys for deterministic load order across platforms.
+        for table_name in sorted(data):
+            payload = data[table_name]
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"{path}: top-level entry {table_name!r} must be a TOML table, got {type(payload).__name__}"
+                )
+            payload_dict = cast(dict[str, object], dict(payload))
+            payload_dict.setdefault("name", table_name)
+            try:
+                sig = PluginSignature.model_validate(payload_dict)
+            except ValidationError as exc:
+                detail = compact_validation_error(exc)
+                raise ValueError(f"{path}: invalid plugin signature {table_name!r}: {detail}") from exc
+            self.register(sig)
+
+    def load_directory(self, directory: Path) -> None:
+        """Load every ``*.toml`` file in ``directory`` (non-recursive).
+
+        Files are loaded in sorted order so two directories with the
+        same files produce the same registry state. Missing or non-
+        directory paths are silently ignored — the bundled
+        ``plugin_signatures/`` directory ships empty in v0.2 so callers
+        can opt into "load bundled if present" without guarding.
+        """
+        directory = Path(directory)
+        if not directory.is_dir():
+            return
+        for entry in sorted(directory.iterdir()):
+            if entry.is_file() and entry.suffix == ".toml":
+                self.load_toml(entry)
+
+    def merge(self, other: PluginSignatureRegistry) -> PluginSignatureRegistry:
+        """Return a new registry combining ``self`` and ``other``.
+
+        Later writes win: any name present in ``other`` overrides the
+        same name in ``self``. Both inputs are left unmodified.
+        """
+        merged: dict[str, PluginSignature] = dict(self._signatures)
+        merged.update(other._signatures)
+        return PluginSignatureRegistry(merged)
+
+    @classmethod
+    def from_paths(
+        cls,
+        files: Iterable[Path] | None = None,
+        directories: Iterable[Path] | None = None,
+    ) -> PluginSignatureRegistry:
+        """Construct a registry from explicit file and directory paths.
+
+        Directories are processed first (in argv order), then individual
+        files (in argv order). Later sources override earlier ones
+        (last-write-wins) — this matches users' mental model of
+        ``--plugin-signatures-dir defaults --plugin-signatures override.toml``.
+        """
+        registry = cls()
+        for directory in directories or ():
+            registry.load_directory(directory)
+        for file_path in files or ():
+            registry.load_toml(file_path)
+        return registry
+
+
+def load_bundled_registry() -> PluginSignatureRegistry:
+    """Load any signatures bundled with the package.
+
+    v0.2 ships the ``plugin_signatures/`` directory empty (see
+    ``docs/plugin-signatures.md`` for examples that are deliberately
+    docs-only). The loader still consults the directory so future
+    bundled additions need no code change.
+    """
+    registry = PluginSignatureRegistry()
+    bundled_dir = Path(__file__).parent / "plugin_signatures"
+    registry.load_directory(bundled_dir)
+    return registry
+
+
+__all__ = ["PluginSignatureRegistry", "load_bundled_registry"]

--- a/parser_lineage_analyzer/_plugins_signature.py
+++ b/parser_lineage_analyzer/_plugins_signature.py
@@ -12,27 +12,40 @@ Soundness contract: a signature describes the plugin's *shape* (which
 config keys are sources, which are destinations), not its semantics. We
 emit a generic ``signature_dispatched`` SourceRef on each declared
 destination, attributing it to the resolved sources of the declared
-``source_keys``. The ``lineage_status`` on the signature picks the
-status (default ``derived``); ``taint_hint`` adds a per-destination
-taint when set.
+``source_keys`` plus — for map-style destinations — the per-pair RHS
+source. The ``lineage_status`` on the signature picks the status
+(default ``derived``); ``taint_hint`` adds a per-destination taint
+when set; ``dest_value_kind`` is consulted as a hint to disambiguate
+how the destination value should be interpreted.
 """
 
 from __future__ import annotations
 
 from typing import Protocol, cast
 
-from ._analysis_helpers import _add_conditions, _location, _normalize_field_ref
+from ._analysis_helpers import _add_conditions, _location, _normalize_field_ref, _strip_ref
 from ._analysis_state import AnalyzerState
 from ._plugin_config_models import PluginSignature
+from ._types import ConfigValue
 from .ast_nodes import Plugin
 from .config_parser import all_values, as_pairs
-from .model import Lineage, LineageStatus, SourceRef
+from .model import Lineage, LineageStatus, SourceRef, TaintReason
 
 
 class _SignatureContext(Protocol):
     def _resolve_token(self, token: str, state: AnalyzerState, loc: str) -> list[Lineage]: ...
 
-    def _store_destination(self, dest: str, lineages: list[Lineage], loc: str, state: AnalyzerState) -> None: ...
+    def _store_destination(
+        self,
+        dest: str,
+        lineages: list[Lineage],
+        loc: str,
+        state: AnalyzerState,
+        *,
+        append: bool = False,
+    ) -> None: ...
+
+    def _apply_post_plugin_decorators(self, stmt: Plugin, state: AnalyzerState, conditions: list[str]) -> None: ...
 
 
 class SignaturePluginMixin:
@@ -47,66 +60,190 @@ class SignaturePluginMixin:
     ) -> None:
         """Build generic lineage for ``stmt`` using ``sig``'s declared shape.
 
-        Resolves every ``source_keys`` config value to lineage, then
-        writes a ``signature_dispatched`` SourceRef into every
-        ``dest_keys`` value with the signature's declared
-        ``lineage_status``. Sources from the resolved upstream lineage
-        propagate so a downstream query attributes the destination back
-        to the original raw fields.
+        Source resolution accumulates plugin-scope sources from
+        ``sig.source_keys`` once. Destination resolution is then
+        per-value: scalar destinations attribute to plugin-scope sources;
+        map destinations (``replace => { dst => src, ... }``) attribute
+        to plugin-scope sources *plus* the per-pair RHS source so each
+        destination's lineage names the field it actually came from;
+        list destinations (``targets => ["a", "b"]``) attribute each
+        entry to plugin-scope sources.
+
+        After all destinations land we call
+        ``_apply_post_plugin_decorators`` so a ``add_tag`` /
+        ``add_field`` / ``remove_tag`` / ``remove_field`` block on the
+        plugin is honored — matching the built-in handlers' behavior.
         """
         context = cast(_SignatureContext, self)
         loc = _location(stmt.line, stmt.name)
 
-        # Aggregate source lineages across every declared source key.
-        source_tokens: list[str] = []
-        source_lineages: list[Lineage] = []
-        for src_key in sig.source_keys:
-            for value in all_values(stmt.config, src_key):
-                if isinstance(value, str):
-                    token = _normalize_field_ref(value)
-                    if token:
-                        source_tokens.append(token)
-                        source_lineages.extend(context._resolve_token(token, state, loc))
+        plugin_source_tokens, plugin_source_lineages = self._resolve_signature_sources(
+            context, stmt, state, loc, sig.source_keys
+        )
 
-        # Resolve destinations. A destination key may be a scalar field
-        # name (``target => "x"``) or a map of dest=>source pairs
-        # (``replace => { "a" => "%{b}", "c" => "%{d}" }``). For maps we
-        # take the *keys* as destinations and merge the value's source
-        # lineage into ``source_lineages`` so the per-destination
-        # attribution stays accurate.
-        destinations: list[str] = []
         for dest_key in sig.dest_keys:
             for value in all_values(stmt.config, dest_key):
+                self._dispatch_destination_value(
+                    context,
+                    stmt,
+                    state,
+                    conditions,
+                    sig,
+                    loc,
+                    value,
+                    plugin_source_tokens,
+                    plugin_source_lineages,
+                )
+
+        # Always run post-plugin decorators, even when a signature
+        # produces no destinations — built-in handlers do the same so
+        # ``add_tag`` etc. fire regardless of the plugin's primary work.
+        context._apply_post_plugin_decorators(stmt, state, conditions)
+
+    @staticmethod
+    def _resolve_signature_sources(
+        context: _SignatureContext,
+        stmt: Plugin,
+        state: AnalyzerState,
+        loc: str,
+        source_keys: list[str],
+    ) -> tuple[list[str], list[Lineage]]:
+        """Walk ``source_keys`` config values and resolve them to lineage.
+
+        Source values commonly use sprintf-style references like
+        ``%{message}``; ``_strip_ref`` removes the ``%{...}`` wrapper so
+        ``_resolve_token`` looks up the bare token name (it does not
+        retry the strip after a literal lookup miss).
+        """
+        tokens: list[str] = []
+        lineages: list[Lineage] = []
+        for src_key in source_keys:
+            for value in all_values(stmt.config, src_key):
                 if isinstance(value, str):
-                    norm = _normalize_field_ref(value)
-                    if norm:
-                        destinations.append(norm)
-                elif isinstance(value, list):
-                    for k, v in as_pairs(value):
-                        if isinstance(k, str):
-                            norm = _normalize_field_ref(k)
-                            if norm:
-                                destinations.append(norm)
-                        if isinstance(v, str):
-                            inner = _normalize_field_ref(v)
-                            if inner:
-                                source_lineages.extend(context._resolve_token(inner, state, loc))
+                    token = _strip_ref(value)
+                    if token:
+                        tokens.append(token)
+                        lineages.extend(context._resolve_token(token, state, loc))
+        return tokens, lineages
 
-        if not destinations:
-            return  # nothing to record; don't emit empty lineage
+    def _dispatch_destination_value(
+        self,
+        context: _SignatureContext,
+        stmt: Plugin,
+        state: AnalyzerState,
+        conditions: list[str],
+        sig: PluginSignature,
+        loc: str,
+        value: ConfigValue,
+        plugin_source_tokens: list[str],
+        plugin_source_lineages: list[Lineage],
+    ) -> None:
+        """Interpret one ``dest_keys`` config value and emit lineage.
 
-        # The signature's declared status drives the LineageStatus we
-        # attach. ``conditional`` is auto-applied if there are active
-        # branch conditions (preserves existing analyzer convention even
-        # when the signature says ``exact``).
+        Supported value shapes:
+          * scalar string — single destination, plugin-scope sources.
+          * list-of-pairs (``map``) — each pair is ``(dest, source_expr)``;
+            destination's lineage attributes to plugin-scope sources
+            *plus* the pair's resolved RHS so per-destination
+            attribution is preserved.
+          * plain list (``list``) — each string entry is a destination,
+            attributed to plugin-scope sources.
+
+        ``sig.dest_value_kind`` disambiguates the list-vs-map decision
+        when a list value contains no pairs (e.g. ``["a", "b"]``):
+        with ``dest_value_kind = "list"`` the entries become destinations,
+        otherwise the empty-pairs list is silently a no-op (back-compat
+        for callers that intended pairs but supplied none).
+        """
+        if isinstance(value, str):
+            dest = _normalize_field_ref(value)
+            if dest:
+                self._emit_signature_lineage(
+                    context,
+                    stmt,
+                    state,
+                    conditions,
+                    sig,
+                    loc,
+                    dest,
+                    plugin_source_tokens,
+                    plugin_source_lineages,
+                )
+            return
+        if not isinstance(value, list):
+            return
+
+        pairs = as_pairs(value)
+        if pairs:
+            # Map shape: per-pair attribution.
+            for k, v in pairs:
+                if not isinstance(k, str):
+                    continue
+                dest = _normalize_field_ref(k)
+                if not dest:
+                    continue
+                pair_tokens = list(plugin_source_tokens)
+                pair_lineages = list(plugin_source_lineages)
+                if isinstance(v, str):
+                    pair_token = _strip_ref(v)
+                    if pair_token:
+                        pair_tokens.append(pair_token)
+                        pair_lineages.extend(context._resolve_token(pair_token, state, loc))
+                self._emit_signature_lineage(
+                    context, stmt, state, conditions, sig, loc, dest, pair_tokens, pair_lineages
+                )
+            return
+
+        # Plain list shape — only honored when the signature declares
+        # ``dest_value_kind = "list"``. Without that hint, a non-pairs
+        # list is most likely a misshapen map and we leave it alone
+        # rather than coercing each entry into a destination.
+        if sig.dest_value_kind == "list":
+            for item in value:
+                if not isinstance(item, str):
+                    continue
+                dest = _normalize_field_ref(item)
+                if dest:
+                    self._emit_signature_lineage(
+                        context,
+                        stmt,
+                        state,
+                        conditions,
+                        sig,
+                        loc,
+                        dest,
+                        plugin_source_tokens,
+                        plugin_source_lineages,
+                    )
+
+    @staticmethod
+    def _emit_signature_lineage(
+        context: _SignatureContext,
+        stmt: Plugin,
+        state: AnalyzerState,
+        conditions: list[str],
+        sig: PluginSignature,
+        loc: str,
+        dest: str,
+        source_tokens: list[str],
+        source_lineages: list[Lineage],
+    ) -> None:
+        """Emit one ``signature_dispatched`` Lineage at ``dest``.
+
+        Each call builds its own SourceRef (and optional taint) from the
+        per-destination ``source_tokens``/``source_lineages`` — never
+        reusing a SourceRef across destinations would cross-attribute
+        the wrong sources for map-style configs.
+
+        ``append=True`` matches the unsupported-plugin fallback path:
+        prior lineage on the destination is preserved instead of
+        overwritten, since a generic handler can't know whether the
+        plugin's real semantics are replace-style or merge-style.
+        """
         declared_status: LineageStatus = sig.lineage_status
         if conditions and declared_status == "exact":
             declared_status = "conditional"
 
-        # Build the attributing SourceRef. ``source_token`` carries a
-        # comma-joined snapshot of resolved source field names so query
-        # output stays human-readable; ``details`` exposes the full
-        # source-ref list for downstream consumers.
         source_token_label = ",".join(source_tokens) if source_tokens else stmt.name
         sources = [
             SourceRef(
@@ -120,10 +257,6 @@ class SignaturePluginMixin:
                 },
             )
         ]
-        # If the signature opts into a taint hint, attach it once per
-        # emitted Lineage (ride-along with the lineage rather than the
-        # broad ``state.add_taint`` so it scopes to the destination).
-        from .model import TaintReason
 
         taints: list[TaintReason] = []
         if sig.taint_hint != "none":
@@ -136,13 +269,12 @@ class SignaturePluginMixin:
                 )
             )
 
-        for dest in destinations:
-            lin = Lineage(
-                status=declared_status,
-                sources=sources,
-                expression=dest,
-                conditions=[],
-                parser_locations=[loc],
-                taints=taints,
-            )
-            context._store_destination(dest, _add_conditions([lin], conditions), loc, state)
+        lin = Lineage(
+            status=declared_status,
+            sources=sources,
+            expression=dest,
+            conditions=[],
+            parser_locations=[loc],
+            taints=taints,
+        )
+        context._store_destination(dest, _add_conditions([lin], conditions), loc, state, append=True)

--- a/parser_lineage_analyzer/_plugins_signature.py
+++ b/parser_lineage_analyzer/_plugins_signature.py
@@ -1,0 +1,148 @@
+"""Generic plugin handler driven by :class:`PluginSignature` declarations.
+
+When :class:`ReverseParser` is constructed with a
+:class:`PluginSignatureRegistry`, the dispatch in
+``_analysis_flow.FlowExecutorMixin._exec_plugin`` consults the registry
+for any plugin name that doesn't match a built-in handler. A registered
+signature routes the invocation here; the absence of one falls through
+to the existing ``unsupported_plugin`` taint path (preserving pre-F3
+behavior byte-for-byte).
+
+Soundness contract: a signature describes the plugin's *shape* (which
+config keys are sources, which are destinations), not its semantics. We
+emit a generic ``signature_dispatched`` SourceRef on each declared
+destination, attributing it to the resolved sources of the declared
+``source_keys``. The ``lineage_status`` on the signature picks the
+status (default ``derived``); ``taint_hint`` adds a per-destination
+taint when set.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, cast
+
+from ._analysis_helpers import _add_conditions, _location, _normalize_field_ref
+from ._analysis_state import AnalyzerState
+from ._plugin_config_models import PluginSignature
+from .ast_nodes import Plugin
+from .config_parser import all_values, as_pairs
+from .model import Lineage, LineageStatus, SourceRef
+
+
+class _SignatureContext(Protocol):
+    def _resolve_token(self, token: str, state: AnalyzerState, loc: str) -> list[Lineage]: ...
+
+    def _store_destination(self, dest: str, lineages: list[Lineage], loc: str, state: AnalyzerState) -> None: ...
+
+
+class SignaturePluginMixin:
+    """Generic handler for plugins routed through :class:`PluginSignature`."""
+
+    def _exec_signature_dispatched(
+        self,
+        stmt: Plugin,
+        state: AnalyzerState,
+        conditions: list[str],
+        sig: PluginSignature,
+    ) -> None:
+        """Build generic lineage for ``stmt`` using ``sig``'s declared shape.
+
+        Resolves every ``source_keys`` config value to lineage, then
+        writes a ``signature_dispatched`` SourceRef into every
+        ``dest_keys`` value with the signature's declared
+        ``lineage_status``. Sources from the resolved upstream lineage
+        propagate so a downstream query attributes the destination back
+        to the original raw fields.
+        """
+        context = cast(_SignatureContext, self)
+        loc = _location(stmt.line, stmt.name)
+
+        # Aggregate source lineages across every declared source key.
+        source_tokens: list[str] = []
+        source_lineages: list[Lineage] = []
+        for src_key in sig.source_keys:
+            for value in all_values(stmt.config, src_key):
+                if isinstance(value, str):
+                    token = _normalize_field_ref(value)
+                    if token:
+                        source_tokens.append(token)
+                        source_lineages.extend(context._resolve_token(token, state, loc))
+
+        # Resolve destinations. A destination key may be a scalar field
+        # name (``target => "x"``) or a map of dest=>source pairs
+        # (``replace => { "a" => "%{b}", "c" => "%{d}" }``). For maps we
+        # take the *keys* as destinations and merge the value's source
+        # lineage into ``source_lineages`` so the per-destination
+        # attribution stays accurate.
+        destinations: list[str] = []
+        for dest_key in sig.dest_keys:
+            for value in all_values(stmt.config, dest_key):
+                if isinstance(value, str):
+                    norm = _normalize_field_ref(value)
+                    if norm:
+                        destinations.append(norm)
+                elif isinstance(value, list):
+                    for k, v in as_pairs(value):
+                        if isinstance(k, str):
+                            norm = _normalize_field_ref(k)
+                            if norm:
+                                destinations.append(norm)
+                        if isinstance(v, str):
+                            inner = _normalize_field_ref(v)
+                            if inner:
+                                source_lineages.extend(context._resolve_token(inner, state, loc))
+
+        if not destinations:
+            return  # nothing to record; don't emit empty lineage
+
+        # The signature's declared status drives the LineageStatus we
+        # attach. ``conditional`` is auto-applied if there are active
+        # branch conditions (preserves existing analyzer convention even
+        # when the signature says ``exact``).
+        declared_status: LineageStatus = sig.lineage_status
+        if conditions and declared_status == "exact":
+            declared_status = "conditional"
+
+        # Build the attributing SourceRef. ``source_token`` carries a
+        # comma-joined snapshot of resolved source field names so query
+        # output stays human-readable; ``details`` exposes the full
+        # source-ref list for downstream consumers.
+        source_token_label = ",".join(source_tokens) if source_tokens else stmt.name
+        sources = [
+            SourceRef(
+                kind="signature_dispatched",
+                source_token=source_token_label,
+                expression=stmt.name,
+                details={
+                    "plugin_name": stmt.name,
+                    "semantic_class": sig.semantic_class,
+                    "upstream_sources": [src.to_json() for lin in source_lineages for src in lin.sources],
+                },
+            )
+        ]
+        # If the signature opts into a taint hint, attach it once per
+        # emitted Lineage (ride-along with the lineage rather than the
+        # broad ``state.add_taint`` so it scopes to the destination).
+        from .model import TaintReason
+
+        taints: list[TaintReason] = []
+        if sig.taint_hint != "none":
+            taints.append(
+                TaintReason(
+                    code=f"signature_dispatched_{sig.taint_hint}",
+                    message=f"signature-dispatched plugin {stmt.name!r} (semantic_class={sig.semantic_class})",
+                    parser_location=loc,
+                    source_token=stmt.name,
+                )
+            )
+
+        for dest in destinations:
+            lin = Lineage(
+                status=declared_status,
+                sources=sources,
+                expression=dest,
+                conditions=[],
+                parser_locations=[loc],
+                taints=taints,
+            )
+            context._store_destination(dest, _add_conditions([lin], conditions), loc, state)

--- a/parser_lineage_analyzer/analyzer.py
+++ b/parser_lineage_analyzer/analyzer.py
@@ -9,6 +9,7 @@ from ._analysis_executor import AnalysisExecutor
 from ._analysis_query import AnalysisQueryMixin
 from ._analysis_state import AnalyzerState
 from ._grok_patterns import GrokLibrary, bundled_library, load_library_from_paths
+from ._plugin_signatures import PluginSignatureRegistry
 from .model import Lineage, SourceRef
 from .parser import parse_code_with_diagnostics
 
@@ -30,6 +31,7 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         max_parser_bytes: int = MAX_PARSER_BYTES,
         mutate_canonical_order: bool = False,
         grok_patterns_dir: Sequence[Path | str] | None = None,
+        plugin_signatures: PluginSignatureRegistry | None = None,
     ):
         """Construct a static lineage engine over a SecOps/Chronicle parser.
 
@@ -50,6 +52,11 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         argument order determines merge order with last-write-wins (matches
         Logstash ``patterns_dir`` semantics). The bundled library is always
         loaded first as the base layer.
+
+        ``plugin_signatures`` is an optional :class:`PluginSignatureRegistry`
+        teaching the analyzer how to model unknown plugins. When ``None``
+        (the default), unknown plugins fall through to the ``unsupported_plugin``
+        taint path — preserving pre-F3 behavior byte-for-byte.
 
         Raises ``TypeError`` if ``parser_code`` is not a ``str`` and
         ``ValueError`` if the encoded size exceeds ``max_parser_bytes``.
@@ -76,6 +83,11 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         if grok_patterns_dir:
             user_paths = [Path(p) for p in grok_patterns_dir]
             self.grok_library = self.grok_library.merge(load_library_from_paths(user_paths))
+        # F3 (PR-D): plugin signature registry. Read by ``_exec_plugin``
+        # in the unknown-plugin fallback to route to a generic handler
+        # instead of the ``unsupported_plugin`` taint path. ``None``
+        # preserves pre-F3 behavior.
+        self.plugin_signatures: PluginSignatureRegistry | None = plugin_signatures
         self._init_state()
         for diag in self.parse_diagnostics:
             warning = (

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -105,6 +105,31 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "sorted-name order."
         ),
     )
+    parser.add_argument(
+        "--plugin-signatures",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help=(
+            "Load plugin signatures from a TOML FILE. Each top-level table "
+            "describes one plugin (semantic_class, source_keys, dest_keys, "
+            "lineage_status, taint_hint). Repeatable; later --plugin-signatures "
+            "files override earlier ones. Without any signatures, unknown "
+            "plugins fall through to the ``unsupported_plugin`` taint path."
+        ),
+    )
+    parser.add_argument(
+        "--plugin-signatures-dir",
+        action="append",
+        default=[],
+        metavar="DIR",
+        help=(
+            "Load every *.toml file in DIR as plugin signatures (non-recursive). "
+            "Repeatable; --plugin-signatures-dir directories are processed "
+            "first in argv order, then individual --plugin-signatures files; "
+            "later sources override earlier ones."
+        ),
+    )
     return parser
 
 
@@ -365,6 +390,7 @@ def main(argv: list[str] | None = None) -> int:
     if not code.strip():
         print("error: parser input is empty (received 0 non-whitespace bytes)", file=sys.stderr)
         return 1
+    from ._plugin_signatures import PluginSignatureRegistry
     from .analyzer import ReverseParser
 
     # Validate any --grok-patterns-dir paths exist before constructing
@@ -381,12 +407,24 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
+    plugin_signatures: PluginSignatureRegistry | None = None
+    if args.plugin_signatures or args.plugin_signatures_dir:
+        try:
+            plugin_signatures = PluginSignatureRegistry.from_paths(
+                files=[Path(p) for p in args.plugin_signatures],
+                directories=[Path(p) for p in args.plugin_signatures_dir],
+            )
+        except (OSError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
     try:
         rp = ReverseParser(
             code,
             max_parser_bytes=args.max_parser_bytes,
             mutate_canonical_order=args.mutate_canonical_order,
             grok_patterns_dir=args.grok_patterns_dir or None,
+            plugin_signatures=plugin_signatures,
         )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,13 @@ classifiers = [
   "Typing :: Typed",
 ]
 
-dependencies = ["lark>=1.3.1,<2", "pydantic>=2.13.3,<3"]
+dependencies = [
+  "lark>=1.3.1,<2",
+  "pydantic>=2.13.3,<3",
+  # 3.11+ ship ``tomllib`` in the stdlib; pull in ``tomli`` only on 3.10
+  # for the plugin-signature TOML loader.
+  'tomli>=2.0; python_version < "3.11"',
+]
 
 [project.urls]
 Homepage = "https://github.com/JudgeZ/parser-lineage-analyzer"

--- a/tests/fixtures/test_corpus/expected/test_signature_dispatched_plugin.cbn
+++ b/tests/fixtures/test_corpus/expected/test_signature_dispatched_plugin.cbn
@@ -1,0 +1,17 @@
+# EXPECTED BEHAVIOR (paired with test_signature_dispatched_plugin.signatures.toml):
+# A plugin not built into the analyzer (`acme_geo_enrich`) gets dispatched
+# through F3's signature registry instead of the `unsupported_plugin`
+# taint path. The signature declares it an enricher with `source` →
+# `target`; after analysis the target field resolves with a
+# `signature_dispatched` SourceRef, no `unsupported_plugin` taint, and
+# the appropriate `signature_dispatched_derived` taint hint attached.
+#
+# Loaded by tests/test_plugin_signatures.py::TestCorpusFixture (NOT by
+# the standard test_corpus_baseline runner, which doesn't know about
+# paired signatures files).
+filter {
+  acme_geo_enrich {
+    source => "client_ip"
+    target => "event.idm.read_only_udm.principal.location.country"
+  }
+}

--- a/tests/fixtures/test_corpus/expected/test_signature_dispatched_plugin.signatures.toml
+++ b/tests/fixtures/test_corpus/expected/test_signature_dispatched_plugin.signatures.toml
@@ -1,0 +1,6 @@
+[acme_geo_enrich]
+semantic_class = "enricher"
+source_keys = ["source"]
+dest_keys = ["target"]
+lineage_status = "derived"
+taint_hint = "derived"

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -16,6 +16,7 @@ Coverage targets:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -129,7 +130,9 @@ class TestRegistryBasics:
 
 
 class TestTomlLoader:
-    def test_load_single_file(self, tmp_path: Path) -> None:
+    def test_load_rejects_top_level_scalar(self, tmp_path: Path) -> None:
+        # Top-level scalars are NOT supported (the file must be a table-of-tables);
+        # a stray scalar makes the loader fail with a clear error.
         f = tmp_path / "sigs.toml"
         f.write_text(
             'name = "ignored_top_level"\n'
@@ -141,8 +144,6 @@ class TestTomlLoader:
             'dest_keys = ["dst"]\n',
             encoding="utf-8",
         )
-        # Top-level scalars are NOT supported (the file must be a table-of-tables);
-        # a stray scalar makes the loader fail with a clear error.
         reg = PluginSignatureRegistry()
         with pytest.raises(ValueError, match="must be a TOML table"):
             reg.load_toml(f)
@@ -430,3 +431,276 @@ class TestCorpusFixture:
         lineages = rp.state.tokens.get("event.idm.read_only_udm.principal.location.country", [])
         codes = {t.code for lin in lineages for t in lin.taints}
         assert "signature_dispatched_derived" in codes
+
+
+# -- Regression tests for review feedback on PR-D ---------------------
+
+
+class TestPR12ReviewFixes:
+    """Regression coverage for Gemini / Codex / CodeRabbit / Copilot findings
+    on PR #12.
+
+    Each test is named after the specific finding it nails down so a
+    future regression is easy to attribute.
+    """
+
+    def test_on_error_block_runs_after_signature_dispatch(self) -> None:
+        # Gemini high (#1): the dispatch's early return used to skip
+        # ``_handle_on_error``. Built-in plugins call it after dispatch;
+        # signature-dispatched plugins must too, so a trailing
+        # ``on_error => "tag"`` (the canonical fail-tag form) is
+        # processed symbolically — landing as a token-level Lineage at
+        # the named flag.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(_sig("custom_enrich", source_keys=["source"], dest_keys=["target"], taint_hint="none"))
+        src = """\
+filter {
+  custom_enrich {
+    source => "message"
+    target => "event.idm.read_only_udm.metadata.product"
+    on_error => "_custom_enrich_failed"
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        # `_handle_on_error` records the flag as a token-level Lineage
+        # with `kind="error_flag"`; presence of that token confirms the
+        # post-dispatch hook fired.
+        flag_lineages = rp.state.tokens.get("_custom_enrich_failed", [])
+        kinds = {src.kind for lin in flag_lineages for src in lin.sources}
+        assert "error_flag" in kinds, (
+            f"on_error flag should be tracked when dispatch runs _handle_on_error; "
+            f"got source kinds {sorted(kinds)} for token '_custom_enrich_failed'"
+        )
+
+    def test_post_plugin_decorators_run_after_signature_dispatch(self) -> None:
+        # Gemini high (#2): built-in handlers call
+        # ``_apply_post_plugin_decorators`` so ``add_tag`` /
+        # ``add_field`` etc. on the plugin take effect. Signature
+        # dispatch must do the same. ``add_tag`` populates
+        # ``state.tag_state.possibly`` (and ``definitely`` on a single
+        # path); ``add_field`` writes a mutate-style destination.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(_sig("decorated_plugin", source_keys=["source"], dest_keys=["target"], taint_hint="none"))
+        src = """\
+filter {
+  decorated_plugin {
+    source => "message"
+    target => "event.idm.read_only_udm.metadata.product"
+    add_tag => ["_decorated"]
+    add_field => { "event.idm.read_only_udm.metadata.event_type" => "DECORATED" }
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        possibly = sorted(rp.state.tag_state.possibly)
+        assert "_decorated" in possibly, f"add_tag decorator should populate tag_state.possibly; got {possibly}"
+        # add_field is a mutate-style decorator; the field must resolve.
+        result = rp.query("event.idm.read_only_udm.metadata.event_type")
+        assert result.mappings, "add_field decorator should produce lineage"
+
+    def test_signature_destination_appends_to_existing_lineage(self) -> None:
+        # Gemini high (#2): generic handler can't know whether the
+        # plugin's real semantics are replace-style or merge-style, so
+        # ``_store_destination(append=True)`` matches the unsupported-
+        # plugin fallback behavior — prior lineage on the field is
+        # preserved as an alternative path.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(_sig("appender", source_keys=["source"], dest_keys=["target"], taint_hint="none"))
+        # First a mutate.replace lays down lineage; then the signature-
+        # dispatched plugin writes to the same destination. With
+        # append=True both paths survive.
+        src = """\
+filter {
+  mutate {
+    replace => { "event.idm.read_only_udm.metadata.product" => "ORIGINAL" }
+  }
+  appender {
+    source => "message"
+    target => "event.idm.read_only_udm.metadata.product"
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        lineages = rp.state.tokens.get("event.idm.read_only_udm.metadata.product", [])
+        # Expect 2+ lineages: the original mutate plus the signature-dispatched one.
+        kinds = {src.kind for lin in lineages for src in lin.sources}
+        assert "constant" in kinds or "literal" in kinds or "mutate_replace" in kinds, (
+            f"expected prior mutate lineage to survive; got source kinds {sorted(kinds)}"
+        )
+        assert "signature_dispatched" in kinds, (
+            f"expected signature-dispatched lineage to be added; got source kinds {sorted(kinds)}"
+        )
+
+    def test_per_destination_source_attribution_for_map_signatures(self) -> None:
+        # Codex P1 (#3): with one shared ``source_lineages`` accumulator,
+        # every destination in ``replace => {a => x, b => y}`` got the
+        # union of x AND y. Per-destination tracking now attributes
+        # each destination to its own source.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "fanout_distinct_sources",
+                semantic_class="mutate_like",
+                source_keys=[],
+                dest_keys=["replace"],
+                dest_value_kind="map",
+            )
+        )
+        # Distinct sources for each destination. Confirm each destination's
+        # upstream sources include its own RHS but NOT the other's.
+        src = """\
+filter {
+  grok {
+    match => { "message" => "%{WORD:left} %{WORD:right}" }
+  }
+  fanout_distinct_sources {
+    replace => {
+      "event.idm.read_only_udm.metadata.product" => "%{left}"
+      "event.idm.read_only_udm.metadata.vendor"  => "%{right}"
+    }
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+
+        def _upstream_capture_names(lineages: list) -> set[str]:
+            """Pull every ``capture_name`` from each lineage's signature-
+            dispatched upstream_sources. The grok captures both write a
+            SourceRef whose ``source_token`` is the parent ``message``,
+            so per-destination distinctness shows up only in
+            ``capture_name`` (``"left"`` vs ``"right"``)."""
+            names: set[str] = set()
+            for lin in lineages:
+                for src in lin.sources:
+                    upstream = src.details.get("upstream_sources") if src.details else None
+                    if not isinstance(upstream, (list, tuple)):
+                        continue
+                    for upstream_ref in upstream:
+                        if isinstance(upstream_ref, Mapping):
+                            cap = upstream_ref.get("capture_name")
+                            if isinstance(cap, str):
+                                names.add(cap)
+            return names
+
+        product_lins = rp.state.tokens.get("event.idm.read_only_udm.metadata.product", [])
+        vendor_lins = rp.state.tokens.get("event.idm.read_only_udm.metadata.vendor", [])
+        # Filter to just the signature-dispatched lineages.
+        product_sig_lins = [lin for lin in product_lins if any(s.kind == "signature_dispatched" for s in lin.sources)]
+        vendor_sig_lins = [lin for lin in vendor_lins if any(s.kind == "signature_dispatched" for s in lin.sources)]
+        assert product_sig_lins, "product should have signature-dispatched lineage"
+        assert vendor_sig_lins, "vendor should have signature-dispatched lineage"
+        product_captures = _upstream_capture_names(product_sig_lins)
+        vendor_captures = _upstream_capture_names(vendor_sig_lins)
+        # Product attributes back to "left" but NOT "right".
+        assert "left" in product_captures, (
+            f"product should attribute to grok capture 'left'; got {sorted(product_captures)}"
+        )
+        assert "right" not in product_captures, (
+            f"product MUST NOT attribute to capture 'right' (per-destination bug); got {sorted(product_captures)}"
+        )
+        # Vendor attributes back to "right" but NOT "left".
+        assert "right" in vendor_captures, (
+            f"vendor should attribute to grok capture 'right'; got {sorted(vendor_captures)}"
+        )
+        assert "left" not in vendor_captures, (
+            f"vendor MUST NOT attribute to capture 'left' (per-destination bug); got {sorted(vendor_captures)}"
+        )
+
+    def test_dest_value_kind_list_produces_destinations(self) -> None:
+        # Codex P1 (#4): ``dest_value_kind = "list"`` was documented but
+        # never implemented. A plain list of destination field names
+        # (``targets => ["a", "b"]``) is now honored when the signature
+        # opts into the list shape.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "fanout_list",
+                semantic_class="enricher",
+                source_keys=["source"],
+                dest_keys=["targets"],
+                dest_value_kind="list",
+            )
+        )
+        src = """\
+filter {
+  fanout_list {
+    source => "message"
+    targets => [
+      "event.idm.read_only_udm.metadata.product",
+      "event.idm.read_only_udm.metadata.vendor"
+    ]
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        for dest in (
+            "event.idm.read_only_udm.metadata.product",
+            "event.idm.read_only_udm.metadata.vendor",
+        ):
+            assert rp.state.tokens.get(dest), f"dest_value_kind='list' should produce lineage for {dest}"
+
+    def test_sprintf_source_ref_is_stripped_before_resolve(self) -> None:
+        # Copilot (#5): source values commonly use ``%{message}``-style
+        # sprintf refs. Without ``_strip_ref``, ``_resolve_token`` looks
+        # up the literal ``%{message}`` and falls through to unresolved.
+        # The fix routes source values through ``_strip_ref`` first.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "sprintf_source_plugin",
+                semantic_class="enricher",
+                source_keys=["source"],
+                dest_keys=["target"],
+                taint_hint="none",
+            )
+        )
+        src = """\
+filter {
+  sprintf_source_plugin {
+    source => "%{message}"
+    target => "event.idm.read_only_udm.metadata.product"
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        lineages = rp.state.tokens.get("event.idm.read_only_udm.metadata.product", [])
+        assert lineages
+        # The signature-dispatched lineage should attribute back to
+        # "message" (the raw token) via upstream_sources, NOT to the
+        # literal "%{message}" string.
+        sig_lins = [lin for lin in lineages if any(s.kind == "signature_dispatched" for s in lin.sources)]
+        assert sig_lins
+        upstream_token_names: set[str] = set()
+        for lin in sig_lins:
+            for src in lin.sources:
+                upstream = src.details.get("upstream_sources") if src.details else None
+                if not isinstance(upstream, (list, tuple)):
+                    continue
+                for ref in upstream:
+                    if isinstance(ref, Mapping):
+                        tok = ref.get("source_token")
+                        if isinstance(tok, str):
+                            upstream_token_names.add(tok)
+        assert "message" in upstream_token_names, (
+            f"upstream attribution should resolve %{{message}} to the 'message' token; "
+            f"got {sorted(upstream_token_names)}"
+        )

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -1,0 +1,432 @@
+"""Tests for the plugin signature registry (F3, PR-D).
+
+Coverage targets:
+* Registry: register / lookup / contains / merge / from_paths.
+* TOML loader: single file, directory, sorted-key determinism, default
+  ``name`` from table key, validation error → ValueError mapping.
+* Bundled registry returns an empty registry (no signatures shipped in v0.2).
+* Pydantic ``extra="forbid"`` rejects unknown signature keys.
+* End-to-end dispatch: a registered fake plugin produces signature-dispatched
+  lineage with the declared semantic_class / lineage_status / sources.
+* Regression guard: an unregistered unknown plugin still hits the
+  ``unsupported_plugin`` taint path.
+* CLI flag plumbing: ``--plugin-signatures`` and ``--plugin-signatures-dir``
+  reach ``ReverseParser``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from parser_lineage_analyzer._plugin_config_models import PluginSignature
+from parser_lineage_analyzer._plugin_signatures import (
+    PluginSignatureRegistry,
+    load_bundled_registry,
+)
+
+
+def _sig(name: str, **overrides: object) -> PluginSignature:
+    """Concise factory for tests; defaults to a single-source/single-dest enricher."""
+    payload: dict[str, object] = {
+        "name": name,
+        "semantic_class": "enricher",
+        "source_keys": ["source"],
+        "dest_keys": ["target"],
+        "lineage_status": "derived",
+        "taint_hint": "none",
+    }
+    payload.update(overrides)
+    return PluginSignature.model_validate(payload)
+
+
+# -- PluginSignature pydantic model -----------------------------------
+
+
+class TestPluginSignatureModel:
+    def test_basic_construction(self) -> None:
+        sig = _sig("foo")
+        assert sig.name == "foo"
+        assert sig.semantic_class == "enricher"
+        assert sig.source_keys == ["source"]
+        assert sig.dest_keys == ["target"]
+        assert sig.lineage_status == "derived"
+        assert sig.taint_hint == "none"
+        assert sig.in_place is False
+        assert sig.dest_value_kind == "scalar"
+
+    @pytest.mark.parametrize("cls", ["extractor", "enricher", "transform", "mutate_like", "passthrough"])
+    def test_all_semantic_classes_accepted(self, cls: str) -> None:
+        sig = _sig("p", semantic_class=cls)
+        assert sig.semantic_class == cls
+
+    def test_typo_in_semantic_class_rejected(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PluginSignature.model_validate(
+                {"name": "p", "semantic_class": "extracter", "source_keys": [], "dest_keys": []}
+            )
+
+    def test_extra_field_rejected_loud(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PluginSignature.model_validate(
+                {
+                    "name": "p",
+                    "semantic_class": "extractor",
+                    "source_keys": [],
+                    "dest_keys": [],
+                    "destination_keys": ["typo"],  # extra
+                }
+            )
+
+
+# -- PluginSignatureRegistry ------------------------------------------
+
+
+class TestRegistryBasics:
+    def test_register_and_lookup(self) -> None:
+        reg = PluginSignatureRegistry()
+        sig = _sig("foo")
+        reg.register(sig)
+        assert reg.lookup("foo") is sig
+        assert "foo" in reg
+
+    def test_lookup_miss_returns_none(self) -> None:
+        reg = PluginSignatureRegistry()
+        assert reg.lookup("nope") is None
+        assert "nope" not in reg
+
+    def test_register_overwrites(self) -> None:
+        reg = PluginSignatureRegistry()
+        reg.register(_sig("foo", semantic_class="extractor"))
+        reg.register(_sig("foo", semantic_class="enricher"))
+        looked_up = reg.lookup("foo")
+        assert looked_up is not None
+        assert looked_up.semantic_class == "enricher"
+
+    def test_names_sorted(self) -> None:
+        reg = PluginSignatureRegistry()
+        reg.register(_sig("zebra"))
+        reg.register(_sig("alpha"))
+        reg.register(_sig("mango"))
+        assert reg.names() == ["alpha", "mango", "zebra"]
+
+    def test_merge_last_write_wins(self) -> None:
+        a = PluginSignatureRegistry({"foo": _sig("foo", semantic_class="extractor")})
+        b = PluginSignatureRegistry({"foo": _sig("foo", semantic_class="enricher")})
+        merged = a.merge(b)
+        assert merged.lookup("foo") is not None
+        assert merged.lookup("foo").semantic_class == "enricher"  # type: ignore[union-attr]
+        # Inputs unmodified.
+        assert a.lookup("foo").semantic_class == "extractor"  # type: ignore[union-attr]
+
+
+# -- TOML loader ------------------------------------------------------
+
+
+class TestTomlLoader:
+    def test_load_single_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            'name = "ignored_top_level"\n'
+            "\n"
+            "[example]\n"
+            'name = "example"\n'
+            'semantic_class = "extractor"\n'
+            'source_keys = ["src"]\n'
+            'dest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        # Top-level scalars are NOT supported (the file must be a table-of-tables);
+        # a stray scalar makes the loader fail with a clear error.
+        reg = PluginSignatureRegistry()
+        with pytest.raises(ValueError, match="must be a TOML table"):
+            reg.load_toml(f)
+
+    def test_load_only_tables(self, tmp_path: Path) -> None:
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            '[example]\nname = "example"\nsemantic_class = "extractor"\nsource_keys = ["src"]\ndest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        reg.load_toml(f)
+        sig = reg.lookup("example")
+        assert sig is not None
+        assert sig.semantic_class == "extractor"
+
+    def test_default_name_from_table_key(self, tmp_path: Path) -> None:
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            '[my_plugin]\nsemantic_class = "passthrough"\nsource_keys = ["src"]\ndest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        reg.load_toml(f)
+        assert reg.lookup("my_plugin") is not None
+
+    def test_invalid_signature_raises_value_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            '[bad]\nsemantic_class = "not_a_real_class"\nsource_keys = ["src"]\ndest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        with pytest.raises(ValueError, match="invalid plugin signature 'bad'"):
+            reg.load_toml(f)
+
+    def test_load_directory_sorts_files(self, tmp_path: Path) -> None:
+        for stem, cls in [("z", "extractor"), ("a", "enricher")]:
+            (tmp_path / f"{stem}.toml").write_text(
+                f"[overlap]\nsemantic_class = {cls!r}\nsource_keys = []\ndest_keys = []\n",
+                encoding="utf-8",
+            )
+        reg = PluginSignatureRegistry()
+        reg.load_directory(tmp_path)
+        # `z.toml` loads after `a.toml` (sorted), so `extractor` wins.
+        sig = reg.lookup("overlap")
+        assert sig is not None
+        assert sig.semantic_class == "extractor"
+
+    def test_load_directory_ignores_non_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "ignored.txt").write_text("garbage", encoding="utf-8")
+        (tmp_path / "real.toml").write_text(
+            '[real]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        reg.load_directory(tmp_path)
+        assert "real" in reg
+        assert "ignored" not in reg
+
+    def test_load_directory_silent_on_missing_path(self, tmp_path: Path) -> None:
+        # Non-directory paths are silently ignored — the bundled directory
+        # ships empty in v0.2 so callers can opt into "load if present"
+        # without guarding.
+        reg = PluginSignatureRegistry()
+        reg.load_directory(tmp_path / "does_not_exist")
+        assert len(reg) == 0
+
+    def test_from_paths_directories_then_files(self, tmp_path: Path) -> None:
+        dir_ = tmp_path / "defaults"
+        dir_.mkdir()
+        (dir_ / "plug.toml").write_text(
+            '[plug]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        override = tmp_path / "override.toml"
+        override.write_text(
+            '[plug]\nsemantic_class = "enricher"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry.from_paths(files=[override], directories=[dir_])
+        sig = reg.lookup("plug")
+        # Files (override) load after directories (defaults), so enricher wins.
+        assert sig is not None
+        assert sig.semantic_class == "enricher"
+
+
+# -- Bundled registry --------------------------------------------------
+
+
+class TestBundledRegistry:
+    def test_empty_in_v0_2(self) -> None:
+        reg = load_bundled_registry()
+        assert len(reg) == 0
+
+
+# -- Dispatch end-to-end ----------------------------------------------
+
+
+class TestDispatch:
+    def test_unregistered_plugin_falls_through_to_unsupported_taint(self) -> None:
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        # No registry: the unknown plugin must still produce the
+        # ``unsupported_plugin`` taint (pre-F3 behavior preserved).
+        src = """\
+filter {
+  totally_made_up_plugin {
+    target => "event.idm.read_only_udm.metadata.product"
+  }
+}
+"""
+        rp = ReverseParser(src)
+        rp.analyze()
+        unsupported = " | ".join(rp.state.unsupported)
+        assert "totally_made_up_plugin" in unsupported
+
+    def test_signature_dispatched_replaces_unsupported_path(self) -> None:
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "totally_made_up_plugin",
+                semantic_class="enricher",
+                source_keys=["source"],
+                dest_keys=["target"],
+                lineage_status="derived",
+                taint_hint="none",
+            )
+        )
+        src = """\
+filter {
+  totally_made_up_plugin {
+    source => "message"
+    target => "event.idm.read_only_udm.metadata.product"
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        # No unsupported_plugin taint.
+        unsupported = " | ".join(rp.state.unsupported)
+        assert "totally_made_up_plugin" not in unsupported
+        # Lineage exists for the destination.
+        result = rp.query("event.idm.read_only_udm.metadata.product")
+        assert result.mappings, "destination should resolve via signature dispatch"
+
+    def test_signature_taint_hint_attaches_per_destination(self) -> None:
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "tainting_plugin",
+                taint_hint="dynamic",
+                source_keys=["source"],
+                dest_keys=["target"],
+            )
+        )
+        src = """\
+filter {
+  tainting_plugin {
+    source => "message"
+    target => "event.idm.read_only_udm.metadata.id"
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        lineages = rp.state.tokens.get("event.idm.read_only_udm.metadata.id", [])
+        assert lineages
+        codes = {t.code for lin in lineages for t in lin.taints}
+        assert "signature_dispatched_dynamic" in codes
+
+    def test_signature_dispatched_with_map_destinations(self) -> None:
+        # ``replace`` style: dest_keys references a map of dest=>source pairs.
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        reg = PluginSignatureRegistry()
+        reg.register(
+            _sig(
+                "fanout_plugin",
+                semantic_class="mutate_like",
+                source_keys=[],
+                dest_keys=["replace"],
+                dest_value_kind="map",
+            )
+        )
+        src = """\
+filter {
+  fanout_plugin {
+    replace => {
+      "event.idm.read_only_udm.metadata.product" => "%{message}"
+      "event.idm.read_only_udm.metadata.vendor"  => "%{message}"
+    }
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=reg)
+        rp.analyze()
+        for dest in (
+            "event.idm.read_only_udm.metadata.product",
+            "event.idm.read_only_udm.metadata.vendor",
+        ):
+            assert rp.state.tokens.get(dest), f"expected lineage for {dest}"
+
+
+# -- CLI plumbing -----------------------------------------------------
+
+
+class TestCliPlumbing:
+    def test_cli_loads_plugin_signatures_file(self, tmp_path: Path) -> None:
+        # Build a minimal parser file that uses an unknown plugin.
+        parser_file = tmp_path / "parser.cbn"
+        parser_file.write_text(
+            'filter { my_special_plugin { source => "message" target => "event.idm.read_only_udm.metadata.product" } }\n',
+            encoding="utf-8",
+        )
+        sigs_file = tmp_path / "sigs.toml"
+        sigs_file.write_text(
+            '[my_special_plugin]\nsemantic_class = "enricher"\nsource_keys = ["source"]\ndest_keys = ["target"]\n',
+            encoding="utf-8",
+        )
+        from parser_lineage_analyzer.cli import main
+
+        rc = main(
+            [
+                str(parser_file),
+                "--summary",
+                "--json",
+                "--plugin-signatures",
+                str(sigs_file),
+            ]
+        )
+        assert rc == 0
+
+    def test_cli_invalid_signature_file_returns_error(self, tmp_path: Path) -> None:
+        parser_file = tmp_path / "parser.cbn"
+        parser_file.write_text('filter { mutate { add_tag => ["x"] } }\n', encoding="utf-8")
+        sigs_file = tmp_path / "bad.toml"
+        sigs_file.write_text(
+            '[bad]\nsemantic_class = "not_real"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        from parser_lineage_analyzer.cli import main
+
+        rc = main([str(parser_file), "--summary", "--json", "--plugin-signatures", str(sigs_file)])
+        assert rc == 1
+
+
+# -- Corpus fixture (loads paired *.signatures.toml) -------------------
+
+
+class TestCorpusFixture:
+    """The standard ``test_corpus_baseline`` runner constructs
+    ``ReverseParser(src)`` with no signatures kwarg, so signature-dispatch
+    fixtures need a dedicated test that knows about the paired TOML."""
+
+    FIXTURE_DIR = Path(__file__).parent / "fixtures" / "test_corpus" / "expected"
+    FIXTURE_NAME = "test_signature_dispatched_plugin"
+
+    def test_signature_dispatched_corpus_fixture(self) -> None:
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        parser_path = self.FIXTURE_DIR / f"{self.FIXTURE_NAME}.cbn"
+        signatures_path = self.FIXTURE_DIR / f"{self.FIXTURE_NAME}.signatures.toml"
+        assert parser_path.exists(), f"missing fixture parser: {parser_path}"
+        assert signatures_path.exists(), f"missing paired signatures: {signatures_path}"
+
+        registry = PluginSignatureRegistry()
+        registry.load_toml(signatures_path)
+        rp = ReverseParser(parser_path.read_text(encoding="utf-8"), plugin_signatures=registry)
+        rp.analyze()
+
+        # The custom enricher's destination resolves via signature dispatch.
+        result = rp.query("event.idm.read_only_udm.principal.location.country")
+        assert result.mappings, "destination should resolve via signature dispatch"
+
+        # No `unsupported_plugin` taint (the registry intercepted the unknown name).
+        unsupported_blob = " | ".join(rp.state.unsupported)
+        assert "acme_geo_enrich" not in unsupported_blob
+
+        # A `signature_dispatched_derived` taint is attached per the signature.
+        lineages = rp.state.tokens.get("event.idm.read_only_udm.principal.location.country", [])
+        codes = {t.code for lin in lineages for t in lin.taints}
+        assert "signature_dispatched_derived" in codes

--- a/tests/test_regex_algebra_properties.py
+++ b/tests/test_regex_algebra_properties.py
@@ -143,7 +143,22 @@ def test_subset_is_reflexive(body: str) -> None:
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_disjoint_is_symmetric(a: str, b: str) -> None:
-    assert regex_languages_disjoint(a, "", b, "") == regex_languages_disjoint(b, "", a, "")
+    # The algebra walks operands left-to-right and threads a shared
+    # ``_Budget`` (states/transitions/wall-clock); under load (CI runners,
+    # GC pauses) the budget can be consumed asymmetrically, so one
+    # direction may reach a definitive YES/NO while the other bails to
+    # ``Trilean.UNKNOWN``. That asymmetry is sound — UNKNOWN is the safe
+    # default and never claims disjointness it can't prove — so we only
+    # require equality when *both* directions reach a definitive answer.
+    # When either side is UNKNOWN the symmetry property is satisfied
+    # trivially (the algebra simply punted one of the two analyses).
+    result_ab = regex_languages_disjoint(a, "", b, "")
+    result_ba = regex_languages_disjoint(b, "", a, "")
+    if result_ab != Trilean.UNKNOWN and result_ba != Trilean.UNKNOWN:
+        assert result_ab == result_ba, (
+            f"unsound: {a!r} vs {b!r} returned {result_ab.value} but "
+            f"{b!r} vs {a!r} returned {result_ba.value} — both definitive results disagree"
+        )
 
 
 @given(_maybe_alternation(), _maybe_alternation())

--- a/tests/test_regex_algebra_properties.py
+++ b/tests/test_regex_algebra_properties.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 
 import re
 
+import pytest
 from hypothesis import HealthCheck, assume, given, settings, strategies as st
 
+from parser_lineage_analyzer import _regex_algebra
 from parser_lineage_analyzer._analysis_condition_facts import (
     conditions_are_compatible,
 )
@@ -40,6 +42,23 @@ from parser_lineage_analyzer._regex_algebra import (
     literal_in_regex_language,
     regex_languages_disjoint,
 )
+
+
+# The production budget (``ALGEBRA_TIME_BUDGET_MS = 25``) is sized for
+# the analyzer's hot path: many algebra calls per branch, all required
+# to settle within a parser run. Property tests run hundreds of varied
+# inputs in succession and want to verify the algebra's *correctness*,
+# not its bail-out behavior — under runner contention (CI GC pauses,
+# scheduler delays) a 25 ms wall-clock budget can fire on inputs that
+# locally complete in <1 ms, producing asymmetric ``UNKNOWN`` results
+# that break properties like ``test_disjoint_is_symmetric``.
+#
+# A 1 s budget per call is still bounded (so a genuine pathological
+# input still bails out) but eliminates the budget-noise flake.
+@pytest.fixture(autouse=True)
+def _generous_algebra_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_regex_algebra, "ALGEBRA_TIME_BUDGET_MS", 1000)
+
 
 # -- Pattern strategies ----------------------------------------------
 
@@ -143,22 +162,7 @@ def test_subset_is_reflexive(body: str) -> None:
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_disjoint_is_symmetric(a: str, b: str) -> None:
-    # The algebra walks operands left-to-right and threads a shared
-    # ``_Budget`` (states/transitions/wall-clock); under load (CI runners,
-    # GC pauses) the budget can be consumed asymmetrically, so one
-    # direction may reach a definitive YES/NO while the other bails to
-    # ``Trilean.UNKNOWN``. That asymmetry is sound — UNKNOWN is the safe
-    # default and never claims disjointness it can't prove — so we only
-    # require equality when *both* directions reach a definitive answer.
-    # When either side is UNKNOWN the symmetry property is satisfied
-    # trivially (the algebra simply punted one of the two analyses).
-    result_ab = regex_languages_disjoint(a, "", b, "")
-    result_ba = regex_languages_disjoint(b, "", a, "")
-    if result_ab != Trilean.UNKNOWN and result_ba != Trilean.UNKNOWN:
-        assert result_ab == result_ba, (
-            f"unsound: {a!r} vs {b!r} returned {result_ab.value} but "
-            f"{b!r} vs {a!r} returned {result_ba.value} — both definitive results disagree"
-        )
+    assert regex_languages_disjoint(a, "", b, "") == regex_languages_disjoint(b, "", a, "")
 
 
 @given(_maybe_alternation(), _maybe_alternation())


### PR DESCRIPTION
## Summary

PR-D of the v0.2 orchestrated-review series. Independent of PR-B ([apps#11](https://github.com/JudgeZ/parser-lineage-analyzer/pull/11)) and PR-C; cleanly composable with both.

Without this PR, any plugin not built into the analyzer (custom org-specific enrichers, vendor filters, Logstash community plugins) hits `_taint_unsupported_plugin_destinations` and produces a hard `unsupported_plugin` taint that kills meaningful lineage. With it, users can describe such plugins via a small declarative TOML file and the analyzer routes the invocation through a generic-but-sound handler that emits `signature_dispatched` lineage attributing each declared destination back to the resolved sources.

## What changed

- **`PluginSignature`** ([_plugin_config_models.py](parser_lineage_analyzer/_plugin_config_models.py)) — pydantic model with `Literal[...]` enums on `semantic_class` / `lineage_status` / `taint_hint` and `extra="forbid"`. Typos surface as loud `ValidationError` at TOML load time.
- **`PluginSignatureRegistry`** (new [_plugin_signatures.py](parser_lineage_analyzer/_plugin_signatures.py)) — wraps a `dict[str, PluginSignature]` with `register` / `lookup` / `merge` / `load_toml` / `load_directory` / `from_paths`. Tables in a TOML file load in sorted-key order; files in a directory load in sorted-name order; argv order across `--plugin-signatures-dir DIR` (processed first) and `--plugin-signatures FILE` (processed second) determines last-write-wins on duplicates.
- **`SignaturePluginMixin._exec_signature_dispatched`** (new [_plugins_signature.py](parser_lineage_analyzer/_plugins_signature.py)) — generic handler. Resolves source tokens via `_resolve_token`, accepts scalar or map `dest_keys`, emits a `signature_dispatched` SourceRef with semantic_class + upstream source-ref details. Honors `signature.lineage_status` (auto-promoting `exact` → `conditional` under active branch conditions) and `signature.taint_hint` (per-destination ride-along, not global state).
- **CLI**: `--plugin-signatures FILE` (repeatable) and `--plugin-signatures-dir DIR` (repeatable). `ReverseParser.__init__(plugin_signatures=PluginSignatureRegistry|None)`.
- **Dispatch wiring** ([_analysis_flow.py:1407](parser_lineage_analyzer/_analysis_flow.py:1407)): the unknown-plugin fallback consults `self.plugin_signatures.lookup(stmt.name)` first; hits route to the generic handler, misses fall through to the existing `unsupported_plugin` taint path.
- **Documentation**: new [docs/plugin-signatures.md](docs/plugin-signatures.md) with full schema, semantic-class taxonomy, three pedagogical examples (enricher / mutate-like / passthrough), CLI + programmatic loading, and the soundness contract. Linked from README.

## Soundness

- **Lookup miss is sound**: pre-F3 behavior preserved byte-for-byte when `plugin_signatures=None` (the default).
- **TOML load failures raise `ValueError`** (CLI returns exit code 1) rather than silently registering a partial signature.
- **The generic handler describes plugin *shape*, not behavior** — declared in the TOML and visible to the user. `signature_dispatched_<hint>` taint lets downstream consumers distinguish "shape-modeled, real semantics not verified" from "fully analyzed".

## Bundled signatures: intentionally none

v0.2 ships `parser_lineage_analyzer/plugin_signatures/` empty (`.keep` only). The loader still consults the directory so future bundled additions need no code change. **Deliberate choice**: shipping signatures someone else wrote for plugins you have not audited produces misleading lineage, which is worse than no lineage. `docs/plugin-signatures.md` ships pedagogical examples instead — copy what fits your environment, audit it, and load it via your own `--plugin-signatures` files.

## Tests ([tests/test_plugin_signatures.py](tests/test_plugin_signatures.py))

29 tests covering:
- **Pydantic model**: construction, every semantic_class accepted, typo rejection, extra-field rejection (`extra="forbid"`)
- **Registry basics**: register / lookup / contains / merge / sorted names
- **TOML loader**: single file, directory, sorted-key ordering, default `name` from table key, validation error → `ValueError`, non-table top-level entries rejected, non-`.toml` files ignored, missing path silently tolerated
- **Bundled registry**: empty in v0.2
- **Dispatch end-to-end**: signature replaces unsupported path; taint hint attaches per-destination; map destinations (`replace => { ... }` style) work; **regression guard** confirms unregistered plugin still hits `unsupported_plugin`
- **CLI plumbing**: `--plugin-signatures` end-to-end + invalid-file error path returns exit code 1
- **Corpus integration**: paired `test_signature_dispatched_plugin.cbn` + `.signatures.toml` fixture loaded via dedicated test (the standard `test_corpus_baseline` runner doesn't know about paired signatures files)

## Verification

- **1489 tests pass** (was 1459 + 28 unit + 1 corpus integration + 1 smoke = 1489)
- **ruff lint + format clean**; **mypy clean** on touched files
- **CLI smoke**: `parser-lineage-analyzer --help` shows the new flags
- **Native parity unaffected** (`_native/` not touched)

## Out of scope

- Bundled real-world signatures (see "Bundled signatures: intentionally none" above for rationale)
- Coupling with PR-C's algebra wiring — `signature_dispatched` destinations carry no resolved-regex constraint today; a future PR could add per-class shape-aware refinements

## Test plan
- [ ] CI passes on Linux/macOS/Windows × py3.10–3.14 (Python 3.10 exercises the `tomli` runtime fallback)
- [ ] Wheel-build matrix imports the new `_plugin_signatures` and `_plugins_signature` modules cleanly
- [ ] CodeRabbit + Copilot/Codex + Gemini review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom plugin signatures via TOML to control how previously unknown plugins produce lineage.
  * New CLI flags to load plugin signature files or directories.

* **Documentation**
  * Added detailed docs and README guidance on authoring and loading plugin signature TOML files.

* **Tests**
  * Added comprehensive tests and fixtures validating signature loading, dispatch behavior, taint outcomes, and CLI handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->