### PR TITLE
release: v0.1.0 orchestrated 3-cycle hardening pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,16 @@ updates:
     open-pull-requests-limit: 5
     versioning-strategy: increase
     groups:
+      # `applies-to: version-updates` scopes these groups to routine weekly
+      # bumps only. Security advisories are NOT grouped, so each Dependabot
+      # security PR ships standalone and can land independently of the
+      # weekly batch — important when one CVE fix would otherwise be held
+      # back behind unrelated dev/prod updates.
       python-dev:
+        applies-to: version-updates
         dependency-type: development
       python-prod:
+        applies-to: version-updates
         dependency-type: production
 
   - package-ecosystem: github-actions
@@ -19,5 +26,6 @@ updates:
     open-pull-requests-limit: 5
     groups:
       actions:
+        applies-to: version-updates
         patterns:
           - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '21 7 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_wheels:
     name: Build wheels (${{ matrix.os }} / ${{ matrix.arch }})
@@ -168,7 +172,7 @@ jobs:
           python -m pip install pytest pytest-timeout hypothesis
           # Pre-install runtime deps from PyPI so the local-wheel install
           # below can use --no-deps and stay pinned to the wheel we built.
-          python -m pip install "lark>=1.1,<2" "pydantic>=2,<3"
+          python -m pip install "lark>=1.3.1,<2" "pydantic>=2,<3"
           python -m pip install --no-index --no-deps --find-links=wheelhouse parser_lineage_analyzer
       - name: Run tests
         shell: bash
@@ -223,5 +227,18 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.10'
+      - name: Validate distributions with twine check
+        # Catch malformed long_description / metadata before the upload action
+        # claims the OIDC token. `twine check` is metadata-only and does not
+        # need PyPI credentials.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install twine
+          python -m twine check dist/*
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Initial public release.
 - `parser-lineage-analyzer` CLI for tracing UDM fields back to the raw-log
   fields, captures, or expressions that populate them in Google SecOps /
   Chronicle parser code.
+- `--include-pattern-bodies` flag opts the resolved grok regex body into JSON `details`.
+- `PERF_SLOW_FACTOR` env var lets CI runners scale perf-test budgets for variance.
 - Public Python API under `parser_lineage_analyzer`:
   - `ReverseParser`, `QueryResult`, `Lineage`, `SourceRef` — analyzer
     entry point and result types.
@@ -43,5 +45,13 @@ Initial public release.
   https://pypi.org/manage/account/publishing/ with the `pypi` environment.
 - Architecture notes in `docs/ARCHITECTURE.md`, security policy in
   `SECURITY.md`, and contributor guide in `CONTRIBUTING.md`.
+
+### Changed
+- `--strict` exit-code semantics clarified in `--help`: parser-level warnings and query-level uncertainty both trigger exit 3.
+- Plain `--json` always emits `unsupported`, `warnings`, `output_anchors`, `structured_warnings`, `diagnostics` (as `[]` when empty); `--json --strict` adds a `strict_failure` object alongside the existing stderr line.
+- Plugin-signature TOML loader: 1 MiB byte cap, malformed TOML wrapped to `ValueError` (no traceback), divergent `[table]` key vs explicit `name` rejected, outward symlink targets in `--plugin-signatures-dir` skipped.
+- Grok pattern loader: 1 MiB per-file size cap and outward symlink targets are skipped.
+- CLI cold-start: `--help` and `--version` no longer import `analyzer`/`pydantic` (~138 ms → ~22 ms on M-series).
+- Re-grok now invalidates a prior implicit grok constraint regardless of body size.
 
 [0.1.0]: https://github.com/JudgeZ/parser-lineage-analyzer/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,13 +45,34 @@ Initial public release.
   https://pypi.org/manage/account/publishing/ with the `pypi` environment.
 - Architecture notes in `docs/ARCHITECTURE.md`, security policy in
   `SECURITY.md`, and contributor guide in `CONTRIBUTING.md`.
+- `--strict` exit-code semantics: any parser-level warning, taint, or
+  unsupported construct, or any query-level uncertainty (unresolved,
+  partial, dynamic), triggers exit 3 (clarified in `--help` text).
+- Plain `--json` always emits `unsupported`, `warnings`,
+  `output_anchors`, `structured_warnings`, `diagnostics` (as `[]` when
+  empty); `--json --strict` adds a `strict_failure` object alongside
+  the existing stderr line.
+- Re-grok invalidates a prior implicit grok constraint regardless of
+  body size, so an oversize-body second grok no longer leaves a stale
+  shape constraint on the captured token.
+- CLI cold-start: `--help` and `--version` skip importing
+  `analyzer`/`pydantic`/`render`/the native extensions (~138 ms → ~25
+  ms on M-series).
 
-### Changed
-- `--strict` exit-code semantics clarified in `--help`: parser-level warnings and query-level uncertainty both trigger exit 3.
-- Plain `--json` always emits `unsupported`, `warnings`, `output_anchors`, `structured_warnings`, `diagnostics` (as `[]` when empty); `--json --strict` adds a `strict_failure` object alongside the existing stderr line.
-- Plugin-signature TOML loader: 1 MiB byte cap, malformed TOML wrapped to `ValueError` (no traceback), divergent `[table]` key vs explicit `name` rejected, outward symlink targets in `--plugin-signatures-dir` skipped.
-- Grok pattern loader: 1 MiB per-file size cap and outward symlink targets are skipped.
-- CLI cold-start: `--help` and `--version` no longer import `analyzer`/`pydantic` (~138 ms → ~22 ms on M-series).
-- Re-grok now invalidates a prior implicit grok constraint regardless of body size.
+### Security
+- Plugin-signature TOML loader: 1 MiB byte cap (enforced via
+  `os.fstat` on the open handle so the cap and the read see the same
+  file), malformed TOML wrapped to `ValueError` (no traceback),
+  divergent `[table]` key vs explicit `name` rejected, and symlinks
+  inside `--plugin-signatures-dir` whose targets resolve outside the
+  configured directory are skipped (the resolved target is read, not
+  the symlink, to defeat retarget races); symlink loops surface as
+  skips rather than tracebacks.
+- Grok pattern loader: 1 MiB per-file size cap (also `os.fstat`-after-
+  open), the same symlink-containment policy, and the same
+  read-the-resolved-target rule applied to `--grok-patterns-dir`.
+- Warning-text rendering regex (`_QUOTED_OVER_ESCAPE`) is bounded
+  ({0,1024} per side) so adversarial parser source can't trigger
+  catastrophic backtracking.
 
 [0.1.0]: https://github.com/JudgeZ/parser-lineage-analyzer/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,13 @@ component while leaving the others native:
 - `PARSER_LINEAGE_ANALYZER_USE_NATIVE_DEDUPE=0`
 - `PARSER_LINEAGE_ANALYZER_USE_NATIVE_BRANCH_MERGE=0`
 
+Only `_DEDUPE` and `_BRANCH_MERGE` expose per-module toggles. The other
+native components (`_SCANNER`, `_TEMPLATE`, `_CONFIG_FAST`) are gated only
+by the global `PARSER_LINEAGE_ANALYZER_NO_EXT=1` switch — there is no
+fine-grained `USE_NATIVE_*` env var for them today, so debugging a
+suspected mismatch in those modules currently requires the global toggle
+plus a bisect.
+
 ## Lint and type-check
 
 The CI bar is the same set of commands a contributor runs locally:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,9 +8,13 @@ recursive-include tests/fixtures *
 # setuptools regenerates `PKG-INFO` and `SOURCES.txt` after MANIFEST
 # processing — these two are spec-required in every sdist. The `prune`
 # line strips any other stale egg-info entries (dependency_links.txt,
-# requires.txt, etc.) left from prior in-tree builds, plus any
-# `__pycache__` trees `recursive-include grok_patterns *` would
-# otherwise sweep in.
+# requires.txt, etc.) left from prior in-tree builds. The
+# ``global-exclude *.py[cod]`` line below matches file basenames
+# (setuptools convention), so it covers ``.pyc``/``.pyo``/``.pyd``
+# anywhere in the tree — including inside ``__pycache__`` directories
+# that ``recursive-include grok_patterns *`` would otherwise sweep in.
+# We don't ``prune __pycache__`` here because that path doesn't exist
+# in the source tree at sdist time; the file-pattern exclude is
+# sufficient to keep bytecode out of the distribution.
 prune parser_lineage_analyzer.egg-info
-global-exclude __pycache__
 global-exclude *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,13 @@ include CHANGELOG.md SECURITY.md CONTRIBUTING.md
 recursive-include parser_lineage_analyzer/grok_patterns *
 recursive-include tests *.py *.cbn *.expected.json *.md *.txt
 recursive-include tests/fixtures *
+
+# setuptools regenerates `PKG-INFO` and `SOURCES.txt` after MANIFEST
+# processing — these two are spec-required in every sdist. The `prune`
+# line strips any other stale egg-info entries (dependency_links.txt,
+# requires.txt, etc.) left from prior in-tree builds, plus any
+# `__pycache__` trees `recursive-include grok_patterns *` would
+# otherwise sweep in.
+prune parser_lineage_analyzer.egg-info
+global-exclude __pycache__
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Mappings:
           source_token: network
           capture_name: dstAddr
           pattern: %{IP:dstAddr}
+
+Warnings:
+  - line 31: mutate.merge duplicate map key 'event.idm.read_only_udm.observer.ip' appears 2 times; keeping the last value (replace/update/add_field/copy/rename/convert) or appending all values (merge)
 ```
 
-(Parser-level warnings, when present, follow the mappings under a `Warnings:`
-heading; pass `--verbose` for parser locations, notes, taints, and
-structured-warning detail.)
+The shipped fixture intentionally contains a duplicate `merge =>` map key so
+the example also demonstrates parser-diagnostic output. Pass `--verbose` for
+parser locations, notes, taints, and structured-warning detail.
 
 A conditional parser returns every reachable mapping with its predicates:
 
@@ -110,10 +113,23 @@ parser-lineage-analyzer PARSER_FILE [UDM_FIELD] [flags]
 | `--summary` | Emit parser/analyzer coverage summary. |
 | `--compact-json` | Bound query JSON for high-cardinality output; samples large arrays, preserves `*_total` counters. |
 | `--compact-summary` | Bound summary diagnostics; includes counts by code. Implies `--summary`. |
-| `--strict` | Exit `3` if the result is unresolved/partial/dynamic, or any warning, taint, or unsupported construct is present. |
+| `--strict` | Exit `3` if any parser-level warning, taint, or unsupported construct is present, OR if the query-level result is unresolved/partial/dynamic. When combined with `--json`/`--compact-json` the same summary is also embedded under a top-level `strict_failure` key. |
 | `--verbose` | Include parser locations, notes, taints, and structured warnings in text output. |
 | `--max-parser-bytes N` | Cap input size in bytes (default `25000000`; `-1` for unlimited). |
 | `--mutate-canonical-order` | Reorder ops within each `mutate{}` block into Logstash's canonical execution order. Default is source order. |
+| `--include-pattern-bodies` | Include the resolved grok regex body in JSON `details`. Off by default to keep `jq` output readable; `resolved_pattern_name` is always emitted. In `--verbose` text mode the body is shown unconditionally. |
+| `--grok-patterns-dir DIR` | Add a directory (or single file) of grok pattern definitions to the bundled Logstash legacy library. Repeatable; later entries override earlier ones. |
+| `--plugin-signatures FILE` | Load plugin signatures from a TOML file. Repeatable; later files override earlier ones. |
+| `--plugin-signatures-dir DIR` | Load every `*.toml` file in DIR as plugin signatures (non-recursive). Repeatable; processed before individual `--plugin-signatures` files. |
+| `--version` | Print the package version and exit. |
+
+Output is plain ASCII; if color is added in a future release, `NO_COLOR`
+will be honored.
+
+`--json` always emits `output_anchors`, `unsupported`, `warnings`,
+`structured_warnings`, and `diagnostics` — as `[]` when empty — so
+downstream consumers can rely on a stable key set. `*_total` counters are
+emitted only by `--compact-json` and remain omitted from plain `--json`.
 
 ### Exit codes
 
@@ -210,6 +226,8 @@ mixed resolved/removed/unresolved paths.
 - Custom or undocumented plugins are reported under `unsupported`.
 - "Which branch did *this* event take?" requires a sample log and is out of
   scope.
+- Regex algebra contradiction-detection is ASCII-aware only; non-ASCII
+  regex predicates degrade to conservative `UNKNOWN`.
 
 ## Testing
 

--- a/parser_lineage_analyzer/_analysis_condition_facts.py
+++ b/parser_lineage_analyzer/_analysis_condition_facts.py
@@ -116,25 +116,15 @@ def _literal_fact_from_normalized_condition(condition: str) -> LiteralFact | Non
     # model uses Python ``re.search`` semantics, where ``$`` matches
     # before a final ``\n``. So ``!~ /^foo$/`` excludes both ``"foo"``
     # *and* ``"foo\n"``, while ``LiteralFact("foo", neq)`` would only
-    # exclude ``"foo"``. Sound on its own, but ``negated_literal_fact_from_condition``
-    # would flip the LiteralFact's ``is_equal`` and produce the false
-    # claim that ``NOT(!~ /^foo$/)`` means ``[t] == "foo"`` — a
-    # *narrower* match-set than the true ``=~ /^foo$/`` semantics. That
-    # narrower set unsoundly contradicts a peer fact like ``[t] != "foo"``
-    # whose witness ``"foo\n"`` lies *outside* the narrowed set but
-    # *inside* the true regex language. Letting ``!~`` stay as a
-    # :class:`RegexFact` keeps the algebra reasoning faithful.
+    # exclude ``"foo"``. Sound on its own, but the negated-literal
+    # reduction would flip the LiteralFact's ``is_equal`` and produce
+    # the false claim that ``NOT(!~ /^foo$/)`` means ``[t] == "foo"``
+    # — a *narrower* match-set than the true ``=~ /^foo$/`` semantics.
+    # That narrower set unsoundly contradicts a peer fact like
+    # ``[t] != "foo"`` whose witness ``"foo\n"`` lies *outside* the
+    # narrowed set but *inside* the true regex language. Letting ``!~``
+    # stay as a :class:`RegexFact` keeps the algebra reasoning faithful.
     return None
-
-
-def negated_literal_fact_from_condition(condition: str) -> LiteralFact | None:
-    m = _NEGATED_RE.match(_normalize_condition(condition))
-    if not m:
-        return None
-    fact = _literal_fact_from_normalized_condition(_normalize_condition(m.group("inner")))
-    if fact is None:
-        return None
-    return fact.negated()
 
 
 def _regex_fact_from_normalized_condition(condition: str) -> RegexFact | None:

--- a/parser_lineage_analyzer/_analysis_executor.py
+++ b/parser_lineage_analyzer/_analysis_executor.py
@@ -35,13 +35,20 @@ def _compute_collision_messages(components: tuple[type, ...]) -> list[str]:
     code) so the regression test in
     ``tests/test_maximal_cleanup_contracts.py`` can pin it by invoking
     this helper rather than re-implementing the loop.
+
+    Identity is the full ``(name, module)`` tuple — two mixins from
+    different modules that happen to share a class name (e.g. both
+    named ``Helpers``) still register as a collision. Comparing only
+    ``__name__`` would have left this real shadowing case undetected.
     """
     seen_methods: dict[str, tuple[str, str]] = {}
     messages: list[str] = []
     for component in components:
+        identity = (component.__name__, component.__module__)
         for method in _component_methods(component):
-            owner_name, owner_module = seen_methods.setdefault(method, (component.__name__, component.__module__))
-            if owner_name != component.__name__:
+            owner = seen_methods.setdefault(method, identity)
+            if owner != identity:
+                owner_name, owner_module = owner
                 messages.append(
                     f"{method} ({owner_name} from {owner_module}, {component.__name__} from {component.__module__})"
                 )

--- a/parser_lineage_analyzer/_analysis_executor.py
+++ b/parser_lineage_analyzer/_analysis_executor.py
@@ -25,15 +25,30 @@ def _component_methods(component: type) -> set[str]:
     return {name for name in component.__dict__ if not name.startswith("__")}
 
 
-_seen_methods: dict[str, tuple[str, str]] = {}
-_collisions: list[str] = []
-for _component in _EXECUTOR_COMPONENTS:
-    for _method in _component_methods(_component):
-        owner_name, owner_module = _seen_methods.setdefault(_method, (_component.__name__, _component.__module__))
-        if owner_name != _component.__name__:
-            _collisions.append(
-                f"{_method} ({owner_name} from {owner_module}, {_component.__name__} from {_component.__module__})"
-            )
+def _compute_collision_messages(components: tuple[type, ...]) -> list[str]:
+    """Return one diagnostic message per (component, method) collision.
+
+    Each message has the form
+    ``"<method> (<owner_name> from <owner_module>, <new_name> from <new_module>)"``
+    so an operator can identify both offending mixins without spelunking
+    through the mixin order. The format string lives here (production
+    code) so the regression test in
+    ``tests/test_maximal_cleanup_contracts.py`` can pin it by invoking
+    this helper rather than re-implementing the loop.
+    """
+    seen_methods: dict[str, tuple[str, str]] = {}
+    messages: list[str] = []
+    for component in components:
+        for method in _component_methods(component):
+            owner_name, owner_module = seen_methods.setdefault(method, (component.__name__, component.__module__))
+            if owner_name != component.__name__:
+                messages.append(
+                    f"{method} ({owner_name} from {owner_module}, {component.__name__} from {component.__module__})"
+                )
+    return messages
+
+
+_collisions = _compute_collision_messages(_EXECUTOR_COMPONENTS)
 if _collisions:
     raise RuntimeError(f"AnalysisExecutor mixin method collision(s): {', '.join(sorted(_collisions))}")
 

--- a/parser_lineage_analyzer/_analysis_executor.py
+++ b/parser_lineage_analyzer/_analysis_executor.py
@@ -25,13 +25,15 @@ def _component_methods(component: type) -> set[str]:
     return {name for name in component.__dict__ if not name.startswith("__")}
 
 
-_seen_methods: dict[str, str] = {}
+_seen_methods: dict[str, tuple[str, str]] = {}
 _collisions: list[str] = []
 for _component in _EXECUTOR_COMPONENTS:
     for _method in _component_methods(_component):
-        owner = _seen_methods.setdefault(_method, _component.__name__)
-        if owner != _component.__name__:
-            _collisions.append(f"{_method} ({owner}, {_component.__name__})")
+        owner_name, owner_module = _seen_methods.setdefault(_method, (_component.__name__, _component.__module__))
+        if owner_name != _component.__name__:
+            _collisions.append(
+                f"{_method} ({owner_name} from {owner_module}, {_component.__name__} from {_component.__module__})"
+            )
 if _collisions:
     raise RuntimeError(f"AnalysisExecutor mixin method collision(s): {', '.join(sorted(_collisions))}")
 

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -544,6 +544,26 @@ class FlowExecutorMixin:
             branch_records.append(BranchRecord(else_state, else_conditions, False))
         else:
             # No-op path: fields can retain their original lineage.
+            #
+            # Perf note: this clone is a per-``if``-without-``else`` allocation
+            # that microbenchmarks attributed ~7% of analyze time to on
+            # parsers dominated by single-arm ``if`` constructs. A COW
+            # alternative (defer the clone to ``_condition_no_op_record``'s
+            # first write) was investigated and rejected here: the no-op
+            # state is also read by ``_apply_dropped_path_conditions``
+            # (which writes ``path_conditions`` when a sibling drops) and
+            # by ``merge_branch_records`` itself (which reads
+            # ``implicit_path_conditions``, ``tag_state``, and
+            # ``path_conditions`` from each survivor). Sharing
+            # ``original`` directly would alias those fields between the
+            # comparison baseline and the no-op survivor, producing
+            # writes to ``original.path_conditions`` and corrupting later
+            # branch comparisons. The minimal-clone path that would work
+            # requires an "AnalyzerState lite" mode whose blast radius
+            # across the existing COW machinery is larger than the perf
+            # win justifies for v0.1. Revisit when we have a concrete,
+            # measured workload that puts this clone on the critical
+            # path beyond the current 7%.
             no_op_state = original.clone()
             no_op_conditions = _dedupe_strings(conditions + _prior_negation_conditions(prior_negations))
             branch_records.append(BranchRecord(no_op_state, no_op_conditions, True))

--- a/parser_lineage_analyzer/_grok_patterns.py
+++ b/parser_lineage_analyzer/_grok_patterns.py
@@ -259,11 +259,19 @@ def load_library_from_paths(paths: Iterable[Path]) -> GrokLibrary:
         if path.is_dir():
             try:
                 resolved_directory = path.resolve()
-            except OSError:  # pragma: no cover - defensive
+            except (OSError, RuntimeError):  # pragma: no cover - defensive
+                # ``Path.resolve()`` raises ``RuntimeError`` on infinite
+                # symlink loops — drop back to the unresolved directory
+                # rather than leaking a traceback.
                 resolved_directory = path
             for entry in sorted(path.iterdir(), key=lambda p: p.name):
                 if entry.name.startswith("."):
                     continue
+                # Default to reading ``entry`` directly. Symlinks that
+                # pass the containment check are loaded via
+                # ``resolved_target`` so a retarget between
+                # ``resolve()`` and the read can't bypass containment.
+                load_path = entry
                 if entry.is_symlink():
                     # Skip symlinks that escape the configured directory.
                     # ``resolve()`` walks the chain; ``path_is_within``
@@ -271,20 +279,23 @@ def load_library_from_paths(paths: Iterable[Path]) -> GrokLibrary:
                     # case-insensitive filesystems (macOS APFS, Windows
                     # NTFS) don't false-positive on a case-mismatched
                     # directory argument. In-dir symlinks (sibling
-                    # links) are still followed.
+                    # links) are still followed. ``resolve()`` raises
+                    # ``RuntimeError`` on cyclic symlink chains — also
+                    # skip those.
                     try:
                         resolved_target = entry.resolve()
-                    except OSError:
+                    except (OSError, RuntimeError):
                         continue
                     if not path_is_within(resolved_target, resolved_directory):
                         continue
-                if not entry.is_file():
+                    load_path = resolved_target
+                if not load_path.is_file():
                     continue
                 # Directory walk: silently drop oversize files (matches
                 # the silent-drop convention for malformed pattern lines
                 # in ``_parse_pattern_file_text``).
                 try:
-                    text = _read_pattern_file_text(entry)
+                    text = _read_pattern_file_text(load_path)
                 except ValueError:
                     continue
                 merged.update(_parse_pattern_file_text(text))

--- a/parser_lineage_analyzer/_grok_patterns.py
+++ b/parser_lineage_analyzer/_grok_patterns.py
@@ -32,6 +32,8 @@ from functools import lru_cache
 from importlib import resources
 from pathlib import Path
 
+from ._path_safety import path_is_within
+
 # Pattern recursion depth — guards against self-references that slip
 # through cycle detection (e.g. mutual recursion through ≥ 33 layers).
 # Set well above the deepest chain in the upstream legacy library
@@ -63,24 +65,6 @@ MAX_PATTERN_FILE_BYTES = 1024 * 1024
 # metadata is the analyzer's concern, handled separately by
 # ``_extract_grok_captures``.
 _GROK_REF_RE = re.compile(r"%\{(?P<name>[A-Za-z0-9_]+)(?::[^}]*)?\}")
-
-
-def _path_is_within(target: Path, base: Path) -> bool:
-    """Return True if ``target`` lies within ``base``, normalising case where
-    ``os.path.normcase`` does (Windows NTFS).
-
-    Mirrors the helper in ``_plugin_signatures.py`` — the two loaders
-    share the same symlink-containment policy and must not drift. See
-    that copy for the full rationale and the POSIX-vs-Windows behaviour
-    of ``os.path.normcase``.
-    """
-    try:
-        target_norm = os.path.normcase(os.fspath(target))
-        base_norm = os.path.normcase(os.fspath(base))
-    except (OSError, ValueError):
-        return False
-    base_norm_with_sep = base_norm if base_norm.endswith(os.sep) else base_norm + os.sep
-    return target_norm == base_norm_with_sep.rstrip(os.sep) or target_norm.startswith(base_norm_with_sep)
 
 
 class GrokLibrary:
@@ -189,19 +173,20 @@ def _is_pattern_data_file(name: str) -> bool:
 def _read_pattern_file_text(path: Path) -> str:
     """Read a pattern file enforcing :data:`MAX_PATTERN_FILE_BYTES`.
 
-    Sizes the file via ``os.path.getsize`` before invoking ``read_text``
-    so we never load a multi-megabyte file into memory. Raises
-    ``ValueError`` when the cap is exceeded; callers that want
-    silent-drop semantics (e.g. directory walks) handle the
-    ``ValueError`` and continue.
+    Sizes the file via ``os.fstat`` on the open handle before reading
+    its contents so the cap check and the read see the same file (no
+    stat-then-open TOCTOU window). Raises ``ValueError`` when the cap
+    is exceeded; callers that want silent-drop semantics (e.g.
+    directory walks) handle the ``ValueError`` and continue.
     """
-    try:
-        size = os.path.getsize(path)
-    except OSError:
-        size = -1
-    if size >= 0 and size > MAX_PATTERN_FILE_BYTES:
-        raise ValueError(f"{path}: grok pattern file exceeds {MAX_PATTERN_FILE_BYTES} bytes")
-    return path.read_text(encoding="utf-8")
+    with path.open("rb") as handle:
+        try:
+            size = os.fstat(handle.fileno()).st_size
+        except OSError:  # pragma: no cover - defensive (fstat almost never fails on an open fd)
+            size = -1
+        if size >= 0 and size > MAX_PATTERN_FILE_BYTES:
+            raise ValueError(f"{path}: grok pattern file exceeds {MAX_PATTERN_FILE_BYTES} bytes")
+        return handle.read().decode("utf-8")
 
 
 def _load_bundled_patterns() -> dict[str, str]:
@@ -281,7 +266,7 @@ def load_library_from_paths(paths: Iterable[Path]) -> GrokLibrary:
                     continue
                 if entry.is_symlink():
                     # Skip symlinks that escape the configured directory.
-                    # ``resolve()`` walks the chain; ``_path_is_within``
+                    # ``resolve()`` walks the chain; ``path_is_within``
                     # checks containment via ``os.path.normcase`` so
                     # case-insensitive filesystems (macOS APFS, Windows
                     # NTFS) don't false-positive on a case-mismatched
@@ -291,7 +276,7 @@ def load_library_from_paths(paths: Iterable[Path]) -> GrokLibrary:
                         resolved_target = entry.resolve()
                     except OSError:
                         continue
-                    if not _path_is_within(resolved_target, resolved_directory):
+                    if not path_is_within(resolved_target, resolved_directory):
                         continue
                 if not entry.is_file():
                     continue

--- a/parser_lineage_analyzer/_grok_patterns.py
+++ b/parser_lineage_analyzer/_grok_patterns.py
@@ -12,10 +12,19 @@ partial expansion when *anything* about the pattern is uncertain
 (missing name, reference cycle, depth bound hit, byte bound hit). The
 analyzer treats ``None`` as "no implicit constraint" — i.e. UNKNOWN —
 which propagates through the algebra as compatible-by-default.
+
+Loader robustness: per-file size cap (``MAX_PATTERN_FILE_BYTES``)
+defends against accidentally pointing the loader at a multi-megabyte
+log/dump. Symlinks whose resolved target sits outside the loaded
+directory are skipped to avoid auto-walking pulling pattern data from
+elsewhere on the filesystem when a directory is enumerated. This
+mirrors the loader policy in ``_plugin_signatures.py`` and is the same
+soundness/safety bar.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import threading
 from collections.abc import Iterable, Mapping
@@ -36,6 +45,17 @@ MAX_GROK_RECURSION_DEPTH = 32
 # ``MAX_REGEX_BODY_BYTES`` threshold downstream.
 MAX_EXPANDED_BODY_BYTES = 8192
 
+# Per-file size cap for the pattern data loader. A real pattern file
+# tops out in the low tens of KB (the bundled Logstash legacy bundle's
+# largest file is well under 32 KB); 1 MiB is a sanity guard against
+# accidentally enumerating a multi-megabyte log or dump that happens to
+# live in a configured ``--grok-patterns-dir``. Enforced before
+# ``read_text`` so we never pin memory on a hostile or accidental huge
+# file. The bundled-loader and explicit-file paths raise ``ValueError``;
+# the directory-walk path silently skips oversize files (matching the
+# loader's existing silent-drop policy for malformed entries).
+MAX_PATTERN_FILE_BYTES = 1024 * 1024
+
 # Matches a Logstash grok reference exactly as the upstream preprocessor
 # does: ``%{NAME}``, ``%{NAME:capture}``, or ``%{NAME:capture:type}``.
 # CAPTURE and TYPE are intentionally stripped during expansion — the
@@ -43,6 +63,24 @@ MAX_EXPANDED_BODY_BYTES = 8192
 # metadata is the analyzer's concern, handled separately by
 # ``_extract_grok_captures``.
 _GROK_REF_RE = re.compile(r"%\{(?P<name>[A-Za-z0-9_]+)(?::[^}]*)?\}")
+
+
+def _path_is_within(target: Path, base: Path) -> bool:
+    """Return True if ``target`` lies within ``base``, normalising case where
+    ``os.path.normcase`` does (Windows NTFS).
+
+    Mirrors the helper in ``_plugin_signatures.py`` — the two loaders
+    share the same symlink-containment policy and must not drift. See
+    that copy for the full rationale and the POSIX-vs-Windows behaviour
+    of ``os.path.normcase``.
+    """
+    try:
+        target_norm = os.path.normcase(os.fspath(target))
+        base_norm = os.path.normcase(os.fspath(base))
+    except (OSError, ValueError):
+        return False
+    base_norm_with_sep = base_norm if base_norm.endswith(os.sep) else base_norm + os.sep
+    return target_norm == base_norm_with_sep.rstrip(os.sep) or target_norm.startswith(base_norm_with_sep)
 
 
 class GrokLibrary:
@@ -148,6 +186,24 @@ def _is_pattern_data_file(name: str) -> bool:
     return not (suffix and suffix in _NON_PATTERN_EXTENSIONS)
 
 
+def _read_pattern_file_text(path: Path) -> str:
+    """Read a pattern file enforcing :data:`MAX_PATTERN_FILE_BYTES`.
+
+    Sizes the file via ``os.path.getsize`` before invoking ``read_text``
+    so we never load a multi-megabyte file into memory. Raises
+    ``ValueError`` when the cap is exceeded; callers that want
+    silent-drop semantics (e.g. directory walks) handle the
+    ``ValueError`` and continue.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        size = -1
+    if size >= 0 and size > MAX_PATTERN_FILE_BYTES:
+        raise ValueError(f"{path}: grok pattern file exceeds {MAX_PATTERN_FILE_BYTES} bytes")
+    return path.read_text(encoding="utf-8")
+
+
 def _load_bundled_patterns() -> dict[str, str]:
     """Parse every data file under ``grok_patterns/`` (skipping NOTICE,
     LICENSE, ``__init__.py``, hidden files, and any file with an
@@ -163,6 +219,10 @@ def _load_bundled_patterns() -> dict[str, str]:
             continue
         if not entry.is_file():
             continue
+        # ``importlib.resources.abc.Traversable.read_text`` doesn't expose
+        # a ``stat``; the bundled directory is a known-finite checked-in
+        # asset, so we trust the existing read here and rely on the byte
+        # cap on user-supplied paths (``load_library_from_paths``).
         out.update(_parse_pattern_file_text(entry.read_text(encoding="utf-8")))
     return out
 
@@ -199,15 +259,54 @@ def _parse_pattern_file_text(text: str) -> dict[str, str]:
 def load_library_from_paths(paths: Iterable[Path]) -> GrokLibrary:
     """Build a library from one or more user-supplied pattern files or
     directories. Files are merged in argument order with last-write-wins;
-    inside a directory, files are merged in sorted-name order."""
+    inside a directory, files are merged in sorted-name order.
+
+    Per-file safety: the byte cap (:data:`MAX_PATTERN_FILE_BYTES`) is
+    enforced on every read. Inside a directory walk, oversize files and
+    symlinks pointing outside the directory are silently skipped (the
+    same drop-on-uncertainty policy this module's malformed-line parser
+    uses). When ``path`` is itself an explicit file argument, an oversize
+    file raises ``ValueError`` so the caller's typo or wrong path
+    surfaces as a loud failure rather than an empty library.
+    """
     merged: dict[str, str] = {}
     for path in paths:
         if path.is_dir():
+            try:
+                resolved_directory = path.resolve()
+            except OSError:  # pragma: no cover - defensive
+                resolved_directory = path
             for entry in sorted(path.iterdir(), key=lambda p: p.name):
-                if entry.is_file() and not entry.name.startswith("."):
-                    merged.update(_parse_pattern_file_text(entry.read_text(encoding="utf-8")))
+                if entry.name.startswith("."):
+                    continue
+                if entry.is_symlink():
+                    # Skip symlinks that escape the configured directory.
+                    # ``resolve()`` walks the chain; ``_path_is_within``
+                    # checks containment via ``os.path.normcase`` so
+                    # case-insensitive filesystems (macOS APFS, Windows
+                    # NTFS) don't false-positive on a case-mismatched
+                    # directory argument. In-dir symlinks (sibling
+                    # links) are still followed.
+                    try:
+                        resolved_target = entry.resolve()
+                    except OSError:
+                        continue
+                    if not _path_is_within(resolved_target, resolved_directory):
+                        continue
+                if not entry.is_file():
+                    continue
+                # Directory walk: silently drop oversize files (matches
+                # the silent-drop convention for malformed pattern lines
+                # in ``_parse_pattern_file_text``).
+                try:
+                    text = _read_pattern_file_text(entry)
+                except ValueError:
+                    continue
+                merged.update(_parse_pattern_file_text(text))
         elif path.is_file():
-            merged.update(_parse_pattern_file_text(path.read_text(encoding="utf-8")))
+            # Explicit file argument: oversize is a loud ValueError
+            # (caller pointed at this file deliberately).
+            merged.update(_parse_pattern_file_text(_read_pattern_file_text(path)))
         # Silently skip non-existent paths — caller validates if it cares.
     return GrokLibrary(merged)
 

--- a/parser_lineage_analyzer/_path_safety.py
+++ b/parser_lineage_analyzer/_path_safety.py
@@ -1,0 +1,39 @@
+"""Path-containment helpers shared by loader-side symlink-escape checks.
+
+The plugin-signature (:mod:`._plugin_signatures`) and grok-pattern
+(:mod:`._grok_patterns`) loaders both need to decide whether a symlink
+inside a user-supplied directory escapes that directory. Keeping a
+single implementation here removes the must-not-drift hazard the two
+inline copies previously carried.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def path_is_within(target: Path, base: Path) -> bool:
+    """Return True if ``target`` lies within ``base``, normalising case where
+    ``os.path.normcase`` does (Windows NTFS).
+
+    ``Path.is_relative_to`` compares path strings byte-for-byte and stays
+    case-sensitive even when the underlying filesystem is not. On Windows
+    that mis-classifies an in-dir symlink whose configured directory
+    differs only in case (``C:\\Foo`` vs ``c:\\foo``) as outward-pointing.
+    Routing both sides through ``os.path.normcase`` closes that gap on
+    Windows; on POSIX (Linux, macOS — both case-sensitive at the
+    Python-path-string level) ``normcase`` is identity so behaviour is
+    unchanged. The check is fail-safe: if a case-insensitive volume is
+    ever encountered with case-mismatched arguments, an in-dir symlink is
+    conservatively rejected rather than falsely accepted.
+    """
+    try:
+        target_norm = os.path.normcase(os.fspath(target))
+        base_norm = os.path.normcase(os.fspath(base))
+    except (OSError, ValueError):
+        return False
+    # Ensure ``base`` ends in a separator so ``/foo/bar`` isn't accepted
+    # as inside ``/foo/barbecue``.
+    base_norm_with_sep = base_norm if base_norm.endswith(os.sep) else base_norm + os.sep
+    return target_norm == base_norm_with_sep.rstrip(os.sep) or target_norm.startswith(base_norm_with_sep)

--- a/parser_lineage_analyzer/_plugin_config_models.py
+++ b/parser_lineage_analyzer/_plugin_config_models.py
@@ -1,5 +1,4 @@
 """Pydantic models for plugin configuration validation."""
-# mypy: disable-error-code="explicit-any"
 
 from __future__ import annotations
 
@@ -8,23 +7,23 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
-class _PluginConfig(BaseModel):
+class _PluginConfig(BaseModel):  # type: ignore[explicit-any]
     model_config = ConfigDict(extra="forbid", strict=True)
 
 
-class JsonPluginConfig(_PluginConfig):
+class JsonPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str = "message"
     target: str | None = None
     array_function: str | None = None
 
 
-class XmlPluginConfig(_PluginConfig):
+class XmlPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str = "message"
     xpath: list[object] = Field(default_factory=list)
     namespaces: list[object] = Field(default_factory=list)
 
 
-class KvPluginConfig(_PluginConfig):
+class KvPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str = "message"
     target: str | None = None
     field_split: str | None = None
@@ -38,29 +37,29 @@ class KvPluginConfig(_PluginConfig):
     allow_duplicate_values: bool | None = None
 
 
-class CsvPluginConfig(_PluginConfig):
+class CsvPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str = "message"
     separator: str = ","
     columns: list[str] | None = None
 
 
-class GrokPluginConfig(_PluginConfig):
+class GrokPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     match: list[object] = Field(default_factory=list)
     pattern_definitions: list[object] = Field(default_factory=list)
 
 
-class DissectPluginConfig(_PluginConfig):
+class DissectPluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     mapping: list[object] = Field(default_factory=list)
     match: list[object] = Field(default_factory=list)
 
 
-class DatePluginConfig(_PluginConfig):
+class DatePluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     match: list[object] | None = None
     target: str = "event.idm.read_only_udm.metadata.event_timestamp"
     timezone: str | None = None
 
 
-class Base64PluginConfig(_PluginConfig):
+class Base64PluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str | None = None
     field: str | None = None
     fields: list[object] | str | None = None
@@ -68,7 +67,7 @@ class Base64PluginConfig(_PluginConfig):
     encoding: str = "Standard"
 
 
-class UrlDecodePluginConfig(_PluginConfig):
+class UrlDecodePluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     source: str | None = None
     field: str | None = None
     fields: list[object] | str | None = None
@@ -89,7 +88,7 @@ class UrlDecodePluginConfig(_PluginConfig):
 # TOML load time rather than silently degrading to UNKNOWN) with
 # ``strict=True`` (no implicit type coercion on ``in_place: bool``,
 # etc.).
-class PluginSignature(_PluginConfig):
+class PluginSignature(_PluginConfig):  # type: ignore[explicit-any]
     name: str
     semantic_class: Literal["extractor", "enricher", "transform", "mutate_like", "passthrough"]
     source_keys: list[str] = Field(default_factory=list)

--- a/parser_lineage_analyzer/_plugin_signatures.py
+++ b/parser_lineage_analyzer/_plugin_signatures.py
@@ -25,6 +25,11 @@ write::
     lineage_status = "derived"
     taint_hint = "derived"
 
+If a table provides an explicit ``name`` field, it MUST equal the table
+key. A divergent ``name`` is rejected at load time with a
+``ValueError`` — silently registering under the explicit ``name`` would
+make ``lookup(<table-key>)`` a confusing miss for the user.
+
 See ``docs/plugin-signatures.md`` for the full schema and per-class
 examples.
 
@@ -35,6 +40,14 @@ Lookup miss MUST fall through to the existing ``unsupported_plugin``
 taint path — the dispatcher checks for ``None`` explicitly. Validation
 errors from a malformed TOML table raise ``ValueError`` at load time
 rather than silently registering a partial signature.
+
+Loader robustness: malformed TOML, oversize files, and outward-pointing
+symlinks all raise ``ValueError`` (the CLI catches ``OSError``/
+``ValueError`` and emits a deterministic diagnostic, never a traceback).
+A 1 MiB cap protects against accidental huge files; symlinks resolving
+outside the loaded directory are skipped to avoid unintentionally
+loading TOML from elsewhere on the filesystem when a directory is
+auto-walked.
 
 Determinism
 -----------
@@ -47,6 +60,7 @@ order with last-write-wins.
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -62,6 +76,39 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover - exercised on 3.10 only
     import tomli as tomllib
+
+# Hard cap on a single plugin-signature TOML file. A real registry with
+# hundreds of plugins lands in the tens of KB; 1 MiB is a sanity guard
+# against accidentally pointing the loader at a multi-megabyte log/dump
+# file. Enforced before ``tomllib.load`` so a malicious or accidental
+# huge file can't pin memory or stall the parser.
+_MAX_TOML_BYTES = 1024 * 1024
+
+
+def _path_is_within(target: Path, base: Path) -> bool:
+    """Return True if ``target`` lies within ``base``, normalising case where
+    ``os.path.normcase`` does (Windows NTFS).
+
+    ``Path.is_relative_to`` compares path strings byte-for-byte and stays
+    case-sensitive even when the underlying filesystem is not. On Windows
+    that mis-classifies an in-dir symlink whose configured directory
+    differs only in case (``C:\\Foo`` vs ``c:\\foo``) as outward-pointing.
+    Routing both sides through ``os.path.normcase`` closes that gap on
+    Windows; on POSIX (Linux, macOS — both case-sensitive at the
+    Python-path-string level) ``normcase`` is identity so behaviour is
+    unchanged. The check is fail-safe: if a case-insensitive volume is
+    ever encountered with case-mismatched arguments, an in-dir symlink is
+    conservatively rejected rather than falsely accepted.
+    """
+    try:
+        target_norm = os.path.normcase(os.fspath(target))
+        base_norm = os.path.normcase(os.fspath(base))
+    except (OSError, ValueError):
+        return False
+    # Ensure ``base`` ends in a separator so ``/foo/bar`` isn't accepted
+    # as inside ``/foo/barbecue``.
+    base_norm_with_sep = base_norm if base_norm.endswith(os.sep) else base_norm + os.sep
+    return target_norm == base_norm_with_sep.rstrip(os.sep) or target_norm.startswith(base_norm_with_sep)
 
 
 class PluginSignatureRegistry:
@@ -95,12 +142,37 @@ class PluginSignatureRegistry:
 
         Each top-level table becomes a :class:`PluginSignature` keyed by
         its ``name`` field (defaulting to the table key if omitted).
+        An explicit ``name`` that differs from the table key is rejected
+        with ``ValueError`` to prevent silent ``lookup`` misses.
+
         Tables that fail validation raise ``ValueError`` with a compact
-        diagnostic so the user sees the bad table immediately.
+        diagnostic so the user sees the bad table immediately. Malformed
+        TOML, oversize files, and IO errors all surface as ``ValueError``
+        (or ``OSError`` for the latter) so the CLI's
+        ``(OSError, ValueError)`` catch can produce a deterministic
+        diagnostic instead of leaking a ``TOMLDecodeError`` traceback.
         """
         path = Path(path)
         with path.open("rb") as handle:
-            data = tomllib.load(handle)
+            # Enforce the byte cap before invoking the TOML parser so a
+            # huge file can't pin memory or trigger a slow parse before
+            # we reject it. ``fstat`` on the open handle is the canonical
+            # way to size a file we already opened (avoids a separate
+            # stat-then-open TOCTOU race against the file content).
+            try:
+                size = os.fstat(handle.fileno()).st_size
+            except OSError:  # pragma: no cover - defensive (fstat almost never fails on an open fd)
+                size = -1
+            if size >= 0 and size > _MAX_TOML_BYTES:
+                raise ValueError(f"{path}: plugin-signature TOML exceeds {_MAX_TOML_BYTES} bytes")
+            try:
+                data = tomllib.load(handle)
+            except tomllib.TOMLDecodeError as exc:
+                # CLI catches ``(OSError, ValueError)``; re-raising as
+                # ValueError keeps the failure mode deterministic
+                # ("invalid TOML: <reason>") instead of letting the
+                # traceback escape.
+                raise ValueError(f"{path}: invalid TOML: {exc}") from exc
         if not isinstance(data, dict):  # pragma: no cover - defensive
             raise ValueError(f"{path}: expected a TOML mapping, got {type(data).__name__}")
         # Sort table keys for deterministic load order across platforms.
@@ -111,6 +183,14 @@ class PluginSignatureRegistry:
                     f"{path}: top-level entry {table_name!r} must be a TOML table, got {type(payload).__name__}"
                 )
             payload_dict = cast(dict[str, object], dict(payload))
+            explicit_name = payload_dict.get("name")
+            if explicit_name is not None and explicit_name != table_name:
+                # Silently registering under ``explicit_name`` would make
+                # ``lookup(<table_key>)`` miss — a confusing failure
+                # mode. Reject loudly so the user fixes the TOML.
+                raise ValueError(
+                    f"{path}: table [{table_name}] has explicit name={explicit_name!r} which differs from table key"
+                )
             payload_dict.setdefault("name", table_name)
             try:
                 sig = PluginSignature.model_validate(payload_dict)
@@ -127,11 +207,34 @@ class PluginSignatureRegistry:
         directory paths are silently ignored — the bundled
         ``plugin_signatures/`` directory ships empty in v0.2 so callers
         can opt into "load bundled if present" without guarding.
+
+        Symlinks whose resolved target sits outside the loaded directory
+        are skipped: a configured signatures directory shouldn't
+        unexpectedly pull TOML from elsewhere on the filesystem just
+        because someone dropped a symlink in. Symlinks pointing at
+        siblings inside the same directory are still followed.
         """
         directory = Path(directory)
         if not directory.is_dir():
             return
+        try:
+            resolved_directory = directory.resolve()
+        except OSError:  # pragma: no cover - defensive
+            resolved_directory = directory
         for entry in sorted(directory.iterdir()):
+            if entry.is_symlink():
+                # Reject symlinks that escape the configured directory.
+                # ``resolve()`` walks the chain; ``_path_is_within``
+                # checks containment via ``os.path.normcase`` so a
+                # case-mismatched directory argument on Windows doesn't
+                # false-positive (POSIX is byte-equal — see helper
+                # docstring for the fail-safe rationale).
+                try:
+                    resolved_target = entry.resolve()
+                except OSError:
+                    continue
+                if not _path_is_within(resolved_target, resolved_directory):
+                    continue
             if entry.is_file() and entry.suffix == ".toml":
                 self.load_toml(entry)
 

--- a/parser_lineage_analyzer/_plugin_signatures.py
+++ b/parser_lineage_analyzer/_plugin_signatures.py
@@ -194,24 +194,37 @@ class PluginSignatureRegistry:
             return
         try:
             resolved_directory = directory.resolve()
-        except OSError:  # pragma: no cover - defensive
+        except (OSError, RuntimeError):  # pragma: no cover - defensive
+            # ``Path.resolve()`` raises ``RuntimeError`` on infinite
+            # symlink loops — same skip-worthy outcome as a missing
+            # path: drop back to the un-resolved directory rather than
+            # leaking a traceback.
             resolved_directory = directory
         for entry in sorted(directory.iterdir()):
+            # Default to opening ``entry`` directly. Symlinks that pass
+            # the containment check are loaded via ``resolved_target``
+            # so a retarget between ``resolve()`` and the open can't
+            # bypass the check we just performed.
+            load_path = entry
             if entry.is_symlink():
                 # Reject symlinks that escape the configured directory.
                 # ``resolve()`` walks the chain; ``path_is_within``
                 # checks containment via ``os.path.normcase`` so a
                 # case-mismatched directory argument on Windows doesn't
                 # false-positive (POSIX is byte-equal — see helper
-                # docstring for the fail-safe rationale).
+                # docstring for the fail-safe rationale). ``resolve()``
+                # raises ``RuntimeError`` on a self-referential or
+                # mutually-referential symlink chain — treat that as
+                # another skip-worthy resolution failure.
                 try:
                     resolved_target = entry.resolve()
-                except OSError:
+                except (OSError, RuntimeError):
                     continue
                 if not path_is_within(resolved_target, resolved_directory):
                     continue
-            if entry.is_file() and entry.suffix == ".toml":
-                self.load_toml(entry)
+                load_path = resolved_target
+            if load_path.is_file() and load_path.suffix == ".toml":
+                self.load_toml(load_path)
 
     def merge(self, other: PluginSignatureRegistry) -> PluginSignatureRegistry:
         """Return a new registry combining ``self`` and ``other``.

--- a/parser_lineage_analyzer/_plugin_signatures.py
+++ b/parser_lineage_analyzer/_plugin_signatures.py
@@ -68,6 +68,7 @@ from typing import cast
 
 from pydantic import ValidationError
 
+from ._path_safety import path_is_within
 from ._plugin_config_models import PluginSignature, compact_validation_error
 
 # Standard 3.10-compatible tomllib idiom. ``tomli`` is a runtime dep on
@@ -83,32 +84,6 @@ else:  # pragma: no cover - exercised on 3.10 only
 # file. Enforced before ``tomllib.load`` so a malicious or accidental
 # huge file can't pin memory or stall the parser.
 _MAX_TOML_BYTES = 1024 * 1024
-
-
-def _path_is_within(target: Path, base: Path) -> bool:
-    """Return True if ``target`` lies within ``base``, normalising case where
-    ``os.path.normcase`` does (Windows NTFS).
-
-    ``Path.is_relative_to`` compares path strings byte-for-byte and stays
-    case-sensitive even when the underlying filesystem is not. On Windows
-    that mis-classifies an in-dir symlink whose configured directory
-    differs only in case (``C:\\Foo`` vs ``c:\\foo``) as outward-pointing.
-    Routing both sides through ``os.path.normcase`` closes that gap on
-    Windows; on POSIX (Linux, macOS — both case-sensitive at the
-    Python-path-string level) ``normcase`` is identity so behaviour is
-    unchanged. The check is fail-safe: if a case-insensitive volume is
-    ever encountered with case-mismatched arguments, an in-dir symlink is
-    conservatively rejected rather than falsely accepted.
-    """
-    try:
-        target_norm = os.path.normcase(os.fspath(target))
-        base_norm = os.path.normcase(os.fspath(base))
-    except (OSError, ValueError):
-        return False
-    # Ensure ``base`` ends in a separator so ``/foo/bar`` isn't accepted
-    # as inside ``/foo/barbecue``.
-    base_norm_with_sep = base_norm if base_norm.endswith(os.sep) else base_norm + os.sep
-    return target_norm == base_norm_with_sep.rstrip(os.sep) or target_norm.startswith(base_norm_with_sep)
 
 
 class PluginSignatureRegistry:
@@ -224,7 +199,7 @@ class PluginSignatureRegistry:
         for entry in sorted(directory.iterdir()):
             if entry.is_symlink():
                 # Reject symlinks that escape the configured directory.
-                # ``resolve()`` walks the chain; ``_path_is_within``
+                # ``resolve()`` walks the chain; ``path_is_within``
                 # checks containment via ``os.path.normcase`` so a
                 # case-mismatched directory argument on Windows doesn't
                 # false-positive (POSIX is byte-equal — see helper
@@ -233,7 +208,7 @@ class PluginSignatureRegistry:
                     resolved_target = entry.resolve()
                 except OSError:
                     continue
-                if not _path_is_within(resolved_target, resolved_directory):
+                if not path_is_within(resolved_target, resolved_directory):
                     continue
             if entry.is_file() and entry.suffix == ".toml":
                 self.load_toml(entry)

--- a/parser_lineage_analyzer/_plugins_extractors.py
+++ b/parser_lineage_analyzer/_plugins_extractors.py
@@ -796,21 +796,25 @@ class ExtractorPluginMixin:
             # Keeping only the latest is *also* unsound (the earlier
             # grok could have been the one that matched). Drop both and
             # let the algebra fall back to UNKNOWN-as-compatible.
+            #
+            # Invalidation MUST fire whenever a re-grok happens to
+            # ``tok`` — even when synthesis is skipped (oversize body,
+            # trivial body, invalid token chars, library miss). The new
+            # grok call overwrites ``tok``'s value, so any prior
+            # constraint describing the *previous* shape is now stale.
+            # If we invalidated only on synthesis success, an
+            # oversize-body re-grok would silently retain the stale
+            # constraint and the algebra could falsely flag valid
+            # literals as contradictory. ``had_prior`` is captured
+            # *before* invalidation so the disjunctive-runtime rule
+            # below ("don't replace; let UNKNOWN reign") still fires
+            # correctly when the second grok's body is also synthesizable.
+            had_prior = state.has_implicit_path_condition_for_token(token)
+            state.invalidate_implicit_path_conditions_for_token(token)
             if resolved_body and not _is_trivial_grok_body(resolved_body):
                 implicit = _synthesize_implicit_grok_condition(token, resolved_body)
-                if implicit is not None:
-                    had_prior = state.has_implicit_path_condition_for_token(token)
-                    # Always invalidate (drops descendants too — re-capturing
-                    # into a parent invalidates child structural constraints).
-                    state.invalidate_implicit_path_conditions_for_token(token)
-                    if not had_prior:
-                        state.add_implicit_path_condition(implicit)
-            elif resolved_body:
-                # Trivial / oversize body: still drop any prior constraint
-                # on this token. Re-capturing into ``tok`` overwrites the
-                # value, so the prior shape constraint is now stale even
-                # if we can't synthesize a replacement.
-                state.invalidate_implicit_path_conditions_for_token(token)
+                if implicit is not None and not had_prior:
+                    state.add_implicit_path_condition(implicit)
             captured_tokens.setdefault(token, []).extend(
                 self._capture_lineages(
                     "grok_capture",

--- a/parser_lineage_analyzer/_plugins_extractors.py
+++ b/parser_lineage_analyzer/_plugins_extractors.py
@@ -771,6 +771,16 @@ class ExtractorPluginMixin:
     ) -> None:
         loc = _location(line, "grok.capture", f"source={source_token}")
         source_lineages, _source_resolved = self._resolve_extractor_source("grok", source_token, state, loc)
+        # Track tokens already visited *in this single grok call* so a
+        # later alternative for the same token doesn't paper over an
+        # earlier oversize/trivial alternative. Without this, a pattern
+        # like ``%{HUGE:x}|%{IP:x}`` would invalidate on iter 1 (HUGE
+        # oversize, no constraint added), then iter 2 (IP) would see
+        # ``had_prior=False`` and synthesize an IP-only constraint —
+        # but runtime ``x`` could have come from the HUGE alternative.
+        # Treating "already visited this call" as a prior preserves the
+        # disjunctive-runtime drop-both rule across alternation.
+        seen_tokens_this_call: set[str] = set()
         for m in _GROK_NAMED_RE.finditer(pattern):
             token = m.group("token")
             if not token:
@@ -809,8 +819,9 @@ class ExtractorPluginMixin:
             # *before* invalidation so the disjunctive-runtime rule
             # below ("don't replace; let UNKNOWN reign") still fires
             # correctly when the second grok's body is also synthesizable.
-            had_prior = state.has_implicit_path_condition_for_token(token)
+            had_prior = state.has_implicit_path_condition_for_token(token) or token in seen_tokens_this_call
             state.invalidate_implicit_path_conditions_for_token(token)
+            seen_tokens_this_call.add(token)
             if resolved_body and not _is_trivial_grok_body(resolved_body):
                 implicit = _synthesize_implicit_grok_condition(token, resolved_body)
                 if implicit is not None and not had_prior:

--- a/parser_lineage_analyzer/_regex_algebra.py
+++ b/parser_lineage_analyzer/_regex_algebra.py
@@ -159,12 +159,18 @@ def extract_regex_literal(condition: str) -> RegexLiteral | None:
     condition string.
 
     Returns ``None`` if the condition is not a single ``=~``/``!~``
-    comparison or if the body exceeds ``MAX_REGEX_BODY_BYTES``.
+    comparison, if the body is empty (``[t] =~ //``), or if the body
+    exceeds ``MAX_REGEX_BODY_BYTES``. An empty body matches the empty
+    string under Python's ``re``, so it carries no shape constraint —
+    treating it as a valid extracted literal would only bloat algebra
+    cache keys with degenerate entries.
     """
     match = _EXTRACT_REGEX_LITERAL_RE.match(condition)
     if match is None:
         return None
     body = match.group("body")
+    if not body:
+        return None
     if len(body.encode("utf-8")) > MAX_REGEX_BODY_BYTES:
         return None
     return RegexLiteral(
@@ -362,8 +368,8 @@ def exact_literal_value(condition: str) -> tuple[str, str] | None:
     sibling: under Python ``re.search`` semantics ``$`` matches before a
     final ``\\n``, so ``!~ /^literal$/`` excludes both ``"literal"`` and
     ``"literal\\n"``. Reducing it to ``LiteralFact(literal, is_equal=False)``
-    is sound in isolation but ``negated_literal_fact_from_condition``
-    would flip the ``is_equal`` and produce a *narrower* match-set than
+    is sound in isolation, but the negated-literal reduction would
+    flip the ``is_equal`` and produce a *narrower* match-set than
     ``=~ /^literal$/`` actually has — unsoundly contradicting peer
     facts whose witnesses live outside the narrowed set. ``!~``
     conditions therefore stay as :class:`RegexFact` and the symbolic
@@ -1329,9 +1335,17 @@ def _complete_and_complement_dfa(dfa: _DFA, budget: _Budget) -> _DFA | None:
 def _intersect_empty_dfa(dfa_a: _DFA, dfa_b: _DFA, budget: _Budget) -> Trilean:
     """Intersection emptiness over two DFAs that share an alphabet
     partition. Used by language-subset (where one side is the complement
-    DFA, which only makes sense when fully constructed)."""
+    DFA, which only makes sense when fully constructed).
+
+    A partition mismatch indicates a caller bug, but the file's stated
+    soundness contract is "never raise; degrade to UNKNOWN" — a raised
+    exception would propagate up and crash the analyzer where the only
+    correct fallback is "give up on this comparison and treat the
+    conditions as compatible". Return UNKNOWN so the upstream
+    contradiction check sees a sound-conservative answer.
+    """
     if dfa_a.partition != dfa_b.partition:
-        raise ValueError("DFAs must share the same alphabet partition")
+        return Trilean.UNKNOWN
     num_classes = len(dfa_a.partition)
     start = (dfa_a.start, dfa_b.start)
     seen: set[tuple[int, int]] = {start}
@@ -1395,15 +1409,26 @@ def _ir_for_cached(body: str, flags: str) -> _IR | None:
 # safety from the GIL, but our hand-rolled `if-len; pop; assign`
 # sequence has check-then-act races without an explicit lock.
 
-_DEFINITIVE_DISJOINT_CACHE: OrderedDict[tuple[str, str, str, str], Trilean] = OrderedDict()
-_DEFINITIVE_SUBSET_CACHE: OrderedDict[tuple[str, str, str, str], Trilean] = OrderedDict()
+# Cache keys vary in arity per primitive (4-tuple for binary regex
+# relations, 3-tuple for the unary literal-membership check) so the
+# type alias is just ``tuple[str, ...]`` — keeps all three caches
+# under the same get/put helpers without inventing per-arity machinery.
+_DEFINITIVE_DISJOINT_CACHE: OrderedDict[tuple[str, ...], Trilean] = OrderedDict()
+_DEFINITIVE_SUBSET_CACHE: OrderedDict[tuple[str, ...], Trilean] = OrderedDict()
+# Membership cache for ``literal_in_regex_language``. Keyed
+# ``(literal, body, flags)``. Same skip-on-UNKNOWN policy as the other
+# definitive caches: a transient cap hit must not be memoized.
+_DEFINITIVE_LITERAL_MEMBERSHIP_CACHE: OrderedDict[tuple[str, ...], Trilean] = OrderedDict()
 _DEFINITIVE_CACHE_LOCK = threading.Lock()
 _DEFINITIVE_CACHE_MAX = 4096
 
 
+_DefinitiveKey = tuple[str, ...]
+
+
 def _definitive_get(
-    cache: OrderedDict[tuple[str, str, str, str], Trilean],
-    key: tuple[str, str, str, str],
+    cache: OrderedDict[_DefinitiveKey, Trilean],
+    key: _DefinitiveKey,
 ) -> Trilean | None:
     with _DEFINITIVE_CACHE_LOCK:
         cached = cache.get(key)
@@ -1416,8 +1441,8 @@ def _definitive_get(
 
 
 def _definitive_put(
-    cache: OrderedDict[tuple[str, str, str, str], Trilean],
-    key: tuple[str, str, str, str],
+    cache: OrderedDict[_DefinitiveKey, Trilean],
+    key: _DefinitiveKey,
     value: Trilean,
 ) -> None:
     if value == Trilean.UNKNOWN:
@@ -1534,6 +1559,16 @@ def literal_in_regex_language(literal: str, body: str, flags: str) -> Trilean:
     """
     if len(literal.encode("utf-8")) > MAX_REGEX_BODY_BYTES:
         return Trilean.UNKNOWN
+    key: tuple[str, ...] = (literal, body, flags)
+    cached = _definitive_get(_DEFINITIVE_LITERAL_MEMBERSHIP_CACHE, key)
+    if cached is not None:
+        return cached
+    result = _literal_in_regex_language_compute(literal, body, flags)
+    _definitive_put(_DEFINITIVE_LITERAL_MEMBERSHIP_CACHE, key, result)
+    return result
+
+
+def _literal_in_regex_language_compute(literal: str, body: str, flags: str) -> Trilean:
     # Build the singleton IR ``literal`` (anchored at both ends; no
     # implicit Σ* wrapping) and intersect against the regex body's IR.
     singleton_ir = _ir_for_literal_singleton(literal)

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -282,15 +282,30 @@ def _summary_has_strict_findings(summary: Mapping[str, object]) -> bool:
     return bool(summary.get("unsupported") or summary.get("warnings") or summary.get("taints") or has_strict_diagnostic)
 
 
-def _print_strict_summary_failure(summary: Mapping[str, object]) -> None:
+def _summary_strict_failure_payload(summary: Mapping[str, object]) -> dict[str, object]:
+    """Build the ``strict_failure`` object embedded in summary/list JSON.
+
+    The ``message`` field is identical to the stderr line emitted by
+    :func:`_print_strict_summary_failure`, so machine consumers reading
+    ``strict_failure.message`` see the same text non-JSON consumers see
+    on stderr — without scraping.
+    """
     unsupported_count = _summary_count(summary, "unsupported")
     warnings_count = _summary_count(summary, "warnings")
     taints_count = _summary_count(summary, "taints")
-    print(
-        f"strict: {unsupported_count} unsupported, {warnings_count} warning(s), "
-        f"{taints_count} taint(s) in parser summary",
-        file=sys.stderr,
-    )
+    return {
+        "unsupported": unsupported_count,
+        "warnings": warnings_count,
+        "taints": taints_count,
+        "message": (
+            f"strict: {unsupported_count} unsupported, {warnings_count} warning(s), "
+            f"{taints_count} taint(s) in parser summary"
+        ),
+    }
+
+
+def _print_strict_summary_failure(summary: Mapping[str, object]) -> None:
+    print(_summary_strict_failure_payload(summary)["message"], file=sys.stderr)
 
 
 def _print_summary_count_map(
@@ -508,7 +523,14 @@ def main(argv: list[str] | None = None) -> int:
         summary = rp.analysis_summary(compact=args.compact_summary)
         _warn_if_parse_recovery(_summary_sequence(summary, "structured_warnings"))
         if args.json:
-            print(json.dumps(summary, indent=2))
+            # Embed ``strict_failure`` in the JSON document when --strict
+            # triggers so machine consumers don't have to scrape stderr.
+            # The stderr line below is preserved unchanged for non-JSON
+            # consumers; both surfaces share the same ``message`` text.
+            summary_payload = dict(summary)
+            if args.strict and _summary_has_strict_findings(summary):
+                summary_payload["strict_failure"] = _summary_strict_failure_payload(summary)
+            print(json.dumps(summary_payload, indent=2))
         else:
             from .render import sanitize_for_terminal
 
@@ -564,6 +586,15 @@ def main(argv: list[str] | None = None) -> int:
         # is only needed for the strict gate. Defer the expensive build.
         state = rp.analyze()
         _warn_if_parse_recovery(state.structured_warnings)
+        # Compute the strict gate up front so the JSON path can embed
+        # ``strict_failure`` alongside the cross-mode-stable shape;
+        # ``analysis_summary()`` is the only thing strict needs and is
+        # itself memoised on the parser, so this is cheap.
+        list_strict_payload: dict[str, object] | None = None
+        if args.strict:
+            list_summary = rp.analysis_summary()
+            if _summary_has_strict_findings(list_summary):
+                list_strict_payload = _summary_strict_failure_payload(list_summary)
         if args.json:
             # Cross-mode JSON consumers expect the same top-level keys
             # regardless of which mode produced the document. ``--list``
@@ -572,20 +603,18 @@ def main(argv: list[str] | None = None) -> int:
             # always empty; emitting them as ``[]`` (instead of omitting)
             # keeps the shape stable for ``jq '.warnings | length'`` and
             # similar across query/summary/list modes.
-            print(
-                json.dumps(
-                    {
-                        "udm_fields": fields,
-                        "udm_fields_total": len(fields),
-                        "output_anchors": [],
-                        "warnings": [],
-                        "unsupported": [],
-                        "structured_warnings": [],
-                        "diagnostics": [],
-                    },
-                    indent=2,
-                )
-            )
+            list_payload: dict[str, object] = {
+                "udm_fields": fields,
+                "udm_fields_total": len(fields),
+                "output_anchors": [],
+                "warnings": [],
+                "unsupported": [],
+                "structured_warnings": [],
+                "diagnostics": [],
+            }
+            if list_strict_payload is not None:
+                list_payload["strict_failure"] = list_strict_payload
+            print(json.dumps(list_payload, indent=2))
         elif not fields:
             print("No UDM fields found.")
         else:
@@ -593,12 +622,10 @@ def main(argv: list[str] | None = None) -> int:
 
             for f in fields:
                 print(sanitize_for_terminal(f))
-        if args.strict:
-            list_summary = rp.analysis_summary()
-            if _summary_has_strict_findings(list_summary):
-                sys.stdout.flush()
-                _print_strict_summary_failure(list_summary)
-                return 3
+        if list_strict_payload is not None:
+            sys.stdout.flush()
+            print(list_strict_payload["message"], file=sys.stderr)
+            return 3
         return 0
     if not args.udm_field:
         print(
@@ -647,10 +674,18 @@ def main(argv: list[str] | None = None) -> int:
     else:
         from .render import render_text
 
+        # Clean only the warning *payload*, not the entire rendered
+        # report — applying the regex post-process to mappings/conditions/
+        # locations text would risk rewriting user data that happens to
+        # contain quoted spans with doubled backslashes (a parser literal
+        # like ``replace => { "x" => '\\\\d+' }`` showing up in a
+        # location label, for instance). Pre-clean ``result.warnings``
+        # before render_text reads it; clean the hint string inline.
+        if result.warnings:
+            result.warnings = [_clean_warning_escapes(w) for w in result.warnings]
         rendered = render_text(result, verbose=args.verbose)
-        rendered = _clean_warning_escapes(rendered)
         if hint is not None:
-            rendered = f"{rendered}\n\nHint:\n  - {hint['warning']}"
+            rendered = f"{rendered}\n\nHint:\n  - {_clean_warning_escapes(hint['warning'])}"
         print(rendered)
     if strict_failure_payload is not None:
         sys.stdout.flush()

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -520,17 +520,29 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Unsupported: {_summary_count(summary, 'unsupported')}")
             print(f"Warnings: {_summary_count(summary, 'warnings')}")
             if args.compact_summary:
-                _print_summary_count_map(summary, "warning_counts", "Warning counts by code")
-                # Always emit the taint heading in compact-summary text mode so
-                # users learn the field exists; ``_print_summary_count_map``
-                # still prints the ``(none)`` placeholder for empty maps.
+                # All three count maps emit their heading even when empty
+                # (with a ``(none)`` placeholder). The discoverability
+                # argument is symmetric: a user who has never seen
+                # warnings/taints/diagnostics shouldn't have to read the
+                # source to learn the field exists.
+                _print_summary_count_map(
+                    summary,
+                    "warning_counts",
+                    "Warning counts by code",
+                    always_show=True,
+                )
                 _print_summary_count_map(
                     summary,
                     "taint_counts",
                     "Taint counts by code",
                     always_show=True,
                 )
-                _print_summary_count_map(summary, "diagnostic_counts", "Diagnostic counts by code")
+                _print_summary_count_map(
+                    summary,
+                    "diagnostic_counts",
+                    "Diagnostic counts by code",
+                    always_show=True,
+                )
             if unsupported:
                 print("Unsupported constructs:")
                 for item in unsupported:

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast
 
 from . import __version__
-from .analyzer import MAX_PARSER_BYTES
-from .render import sanitize_for_terminal
 
 if TYPE_CHECKING:
     from .model import QueryResult
+
+# ``MAX_PARSER_BYTES`` is mirrored as a literal constant here so that
+# ``parser-lineage-analyzer --help`` / ``--version`` do not pull in
+# ``analyzer`` (and its pydantic/lark/native-extension dependency tree).
+# A regression test in ``tests/test_cli_and_public_model.py`` pins this
+# to the analyzer-side definition so a mismatch is caught at CI time.
+MAX_PARSER_BYTES = 25_000_000
 
 _STDIN_READ_CHUNK_CHARS = 64 * 1024
 _UTF8_BOM_BYTES = b"\xef\xbb\xbf"
@@ -54,8 +60,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--strict",
         action="store_true",
         help=(
-            "Exit 3 if the analysis includes warnings, unsupported constructs, or taints, "
-            "or if the query result is unresolved, partial, or dynamic. "
+            "Exit 3 if any parser-level (warning, taint, unsupported construct) "
+            "or query-level (unresolved, partial, dynamic) finding is present. "
             "Applies to --list, --summary, --compact-summary, and query modes."
         ),
     )
@@ -128,6 +134,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Repeatable; --plugin-signatures-dir directories are processed "
             "first in argv order, then individual --plugin-signatures files; "
             "later sources override earlier ones."
+        ),
+    )
+    parser.add_argument(
+        "--include-pattern-bodies",
+        action="store_true",
+        help=(
+            "Include resolved grok pattern bodies (the regex blob) in JSON "
+            "output. By default JSON omits ``resolved_pattern_body`` from "
+            "``details`` to keep ``jq | head`` output readable; "
+            "``resolved_pattern_name`` is always preserved so consumers can "
+            "look the body up by name."
         ),
     )
     return parser
@@ -210,6 +227,36 @@ def _read_parser(path: str, max_parser_bytes: int = MAX_PARSER_BYTES) -> str:
     return text
 
 
+# Inner repetitions are bounded to defeat catastrophic backtracking on
+# adversarial input that lacks a closing quote. Each warning-rendered
+# quoted span is upstream-bounded by ``MAX_REGEX_BODY_BYTES`` (512), so
+# ``{0,1024}`` per side covers the cap with slack while still failing
+# fast (in milliseconds) on a 10K-char string with no terminator.
+_QUOTED_OVER_ESCAPE = re.compile(r"'((?:[^'\\]|\\.){0,1024}\\\\(?:[^'\\]|\\.){0,1024})'")
+
+
+def _clean_warning_escapes(message: str) -> str:
+    """Undo a single layer of Python ``repr()`` doubling on backslashes inside
+    quoted regex fragments in warning messages.
+
+    Several upstream warning helpers (``regex_over_escape_warning``,
+    ``runtime_condition_warning``) build their text with ``f"... {pattern!r}
+    ..."``, which doubles every backslash a second time. The user-facing
+    output should display the source bytes as the user wrote them — single
+    backslashes for ``\\d`` source, not the four-backslash ``\\\\d`` form
+    that ``!r`` produces. Replacing only inside the single-quoted ``'...'``
+    spans avoids touching message prose ("did you mean '\\d'?"), so the
+    suggestion stays accurate while the surrounding regex literal is shown
+    verbatim.
+    """
+
+    def _undouble(match: re.Match[str]) -> str:
+        body = match.group(1)
+        return "'" + body.replace("\\\\", "\\") + "'"
+
+    return _QUOTED_OVER_ESCAPE.sub(_undouble, message)
+
+
 def _summary_sequence(summary: Mapping[str, object], key: str) -> Sequence[object]:
     value = summary.get(key, [])
     return value if isinstance(value, Sequence) and not isinstance(value, str) else []
@@ -246,9 +293,21 @@ def _print_strict_summary_failure(summary: Mapping[str, object]) -> None:
     )
 
 
-def _print_summary_count_map(summary: Mapping[str, object], key: str, heading: str) -> None:
+def _print_summary_count_map(
+    summary: Mapping[str, object],
+    key: str,
+    heading: str,
+    *,
+    always_show: bool = False,
+) -> None:
     counts = _summary_mapping(summary, key)
     if not counts:
+        if not always_show:
+            return
+        # Always-show headings render an explicit ``(none)`` placeholder so
+        # users discover the field exists even on a clean parser.
+        print(f"{heading}:")
+        print("  (none)")
         return
     print(f"{heading}:")
     for code in sorted(counts):
@@ -330,6 +389,22 @@ def _augment_json_with_hint(payload: str, hint: dict[str, str] | None) -> str:
     data = json.loads(payload)
     if isinstance(data, dict):
         data["hint"] = hint
+    return json.dumps(data, indent=2, sort_keys=False)
+
+
+def _augment_json_with_strict_failure(payload: str, failure: dict[str, object] | None) -> str:
+    """Insert a top-level ``strict_failure`` key when ``--strict`` triggers.
+
+    Plain ``--strict`` already prints a one-line summary to stderr; the JSON
+    document mirrors the same structure under ``strict_failure`` so machine
+    consumers don't have to scrape stderr to decide whether to treat the
+    payload as a failure. The stderr line is preserved unchanged.
+    """
+    if failure is None:
+        return payload
+    data = json.loads(payload)
+    if isinstance(data, dict):
+        data["strict_failure"] = failure
     return json.dumps(data, indent=2, sort_keys=False)
 
 
@@ -435,6 +510,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.json:
             print(json.dumps(summary, indent=2))
         else:
+            from .render import sanitize_for_terminal
+
             unsupported = _summary_sequence(summary, "unsupported")
             warnings = _summary_sequence(summary, "warnings")
             print(f"UDM fields: {_summary_count(summary, 'udm_fields')}")
@@ -444,7 +521,15 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Warnings: {_summary_count(summary, 'warnings')}")
             if args.compact_summary:
                 _print_summary_count_map(summary, "warning_counts", "Warning counts by code")
-                _print_summary_count_map(summary, "taint_counts", "Taint counts by code")
+                # Always emit the taint heading in compact-summary text mode so
+                # users learn the field exists; ``_print_summary_count_map``
+                # still prints the ``(none)`` placeholder for empty maps.
+                _print_summary_count_map(
+                    summary,
+                    "taint_counts",
+                    "Taint counts by code",
+                    always_show=True,
+                )
                 _print_summary_count_map(summary, "diagnostic_counts", "Diagnostic counts by code")
             if unsupported:
                 print("Unsupported constructs:")
@@ -453,7 +538,7 @@ def main(argv: list[str] | None = None) -> int:
             if warnings:
                 print("Warnings:")
                 for item in warnings:
-                    print(f"  - {sanitize_for_terminal(str(item))}")
+                    print(f"  - {sanitize_for_terminal(_clean_warning_escapes(str(item)))}")
         if args.strict and _summary_has_strict_findings(summary):
             sys.stdout.flush()
             _print_strict_summary_failure(summary)
@@ -468,10 +553,32 @@ def main(argv: list[str] | None = None) -> int:
         state = rp.analyze()
         _warn_if_parse_recovery(state.structured_warnings)
         if args.json:
-            print(json.dumps({"udm_fields": fields, "udm_fields_total": len(fields)}, indent=2))
+            # Cross-mode JSON consumers expect the same top-level keys
+            # regardless of which mode produced the document. ``--list``
+            # carries no per-query data, so ``output_anchors``/``warnings``/
+            # ``unsupported``/``structured_warnings``/``diagnostics`` are
+            # always empty; emitting them as ``[]`` (instead of omitting)
+            # keeps the shape stable for ``jq '.warnings | length'`` and
+            # similar across query/summary/list modes.
+            print(
+                json.dumps(
+                    {
+                        "udm_fields": fields,
+                        "udm_fields_total": len(fields),
+                        "output_anchors": [],
+                        "warnings": [],
+                        "unsupported": [],
+                        "structured_warnings": [],
+                        "diagnostics": [],
+                    },
+                    indent=2,
+                )
+            )
         elif not fields:
             print("No UDM fields found.")
         else:
+            from .render import sanitize_for_terminal
+
             for f in fields:
                 print(sanitize_for_terminal(f))
         if args.strict:
@@ -490,31 +597,55 @@ def main(argv: list[str] | None = None) -> int:
     result = rp.query(args.udm_field, compact=args.compact_json)
     _warn_if_parse_recovery(result.structured_warnings)
     hint = _extract_query_no_match_hint(result)
-    if args.compact_json:
-        from .render import render_compact_json
-
-        print(_augment_json_with_hint(render_compact_json(result), hint))
-    elif args.json:
-        from .render import render_json
-
-        print(_augment_json_with_hint(render_json(result), hint))
-    else:
-        from .render import render_text
-
-        rendered = render_text(result, verbose=args.verbose)
-        if hint is not None:
-            rendered = f"{rendered}\n\nHint:\n  - {hint['warning']}"
-        print(rendered)
+    strict_failure_payload: dict[str, object] | None = None
     if args.strict and _query_has_strict_findings(result):
         warnings_count = len(result.warnings)
         taints_total = sum(len(mapping.taints) for mapping in result.mappings)
         unsupported_count = len(result.unsupported)
-        sys.stdout.flush()
+        strict_failure_payload = {
+            "status": result.status,
+            "unsupported": unsupported_count,
+            "warnings": warnings_count,
+            "taints": taints_total,
+            "message": (
+                f"strict: query status={result.status}, {unsupported_count} unsupported, "
+                f"{warnings_count} warning(s), {taints_total} taint(s)"
+            ),
+        }
+    if args.compact_json:
+        from .render import render_compact_json
+
+        rendered = render_compact_json(result, include_pattern_bodies=args.include_pattern_bodies)
         print(
-            f"strict: query status={result.status}, {unsupported_count} unsupported, "
-            f"{warnings_count} warning(s), {taints_total} taint(s)",
-            file=sys.stderr,
+            _augment_json_with_strict_failure(
+                _augment_json_with_hint(rendered, hint),
+                strict_failure_payload,
+            )
         )
+    elif args.json:
+        from .render import render_json
+
+        rendered = render_json(result, include_pattern_bodies=args.include_pattern_bodies)
+        print(
+            _augment_json_with_strict_failure(
+                _augment_json_with_hint(rendered, hint),
+                strict_failure_payload,
+            )
+        )
+    else:
+        from .render import render_text
+
+        rendered = render_text(result, verbose=args.verbose)
+        rendered = _clean_warning_escapes(rendered)
+        if hint is not None:
+            rendered = f"{rendered}\n\nHint:\n  - {hint['warning']}"
+        print(rendered)
+    if strict_failure_payload is not None:
+        sys.stdout.flush()
+        # Stderr message is preserved unchanged for back-compat with non-JSON
+        # consumers; the JSON document also carries ``strict_failure`` so
+        # machine consumers don't have to scrape stderr.
+        print(strict_failure_payload["message"], file=sys.stderr)
         return 3
     return 0
 

--- a/parser_lineage_analyzer/model.py
+++ b/parser_lineage_analyzer/model.py
@@ -971,6 +971,13 @@ class QueryResult:
     def to_json(self) -> JSONDict:
         aggregate = self.aggregate()
         diagnostics = self.compute_effective_diagnostics(aggregate)
+        # Schema-stable shape: ``output_anchors``, ``unsupported``,
+        # ``warnings``, ``structured_warnings``, and ``diagnostics`` are
+        # always present (as ``[]`` when empty) so downstream consumers can
+        # rely on a single key set instead of conditional ``.get`` reads.
+        # ``*_total`` counters remain compact-only — they only appear when
+        # the analyzer actually sampled the underlying list (preserving
+        # back-compat with the documented ``--compact-json`` contract).
         data: JSONDict = {
             "udm_field": self.udm_field,
             "status": aggregate.status,
@@ -980,21 +987,16 @@ class QueryResult:
             "has_taints": aggregate.has_taints,
             "normalized_candidates": self.normalized_candidates,
             "mappings": [m.to_json() for m in self.mappings],
+            "output_anchors": [a.to_json() for a in self.output_anchors],
+            "unsupported": list(self.unsupported),
+            "warnings": list(self.warnings),
+            "structured_warnings": [warning.to_json() for warning in self.structured_warnings],
+            "diagnostics": [diagnostic.to_json() for diagnostic in diagnostics],
         }
         if self.normalized_candidates_total is not None:
             data["normalized_candidates_total"] = self.normalized_candidates_total
         if self.mappings_total is not None:
             data["mappings_total"] = self.mappings_total
-        if self.output_anchors:
-            data["output_anchors"] = [a.to_json() for a in self.output_anchors]
-        if self.unsupported:
-            data["unsupported"] = self.unsupported
-        if self.warnings:
-            data["warnings"] = self.warnings
-        if self.structured_warnings:
-            data["structured_warnings"] = [warning.to_json() for warning in self.structured_warnings]
-        if diagnostics:
-            data["diagnostics"] = [diagnostic.to_json() for diagnostic in diagnostics]
         return data
 
 

--- a/parser_lineage_analyzer/render.py
+++ b/parser_lineage_analyzer/render.py
@@ -287,8 +287,41 @@ def render_text(result: QueryResult, *, verbose: bool = False, limit: int | None
     return sanitize_for_terminal("\n".join(lines))
 
 
-def render_json(result: QueryResult) -> str:
-    return json.dumps(result.to_json(), indent=2, sort_keys=False)
+# Detail keys that bloat default JSON output without adding lookup-by-name
+# value. The corresponding name (``resolved_pattern_name``) is always
+# preserved, so consumers can join against an external pattern library when
+# they actually need the body. Opt back in via ``--include-pattern-bodies``.
+_DEFAULT_JSON_DETAIL_OMIT = ("resolved_pattern_body",)
+
+
+def _strip_detail_keys(payload: JSONDict, omit: Sequence[str]) -> JSONDict:
+    if not omit:
+        return payload
+    mappings = payload.get("mappings")
+    if isinstance(mappings, list):
+        for mapping in mappings:
+            if not isinstance(mapping, dict):
+                continue
+            sources = mapping.get("sources")
+            if not isinstance(sources, list):
+                continue
+            for source in sources:
+                if not isinstance(source, dict):
+                    continue
+                details = source.get("details")
+                if isinstance(details, dict):
+                    for key in omit:
+                        details.pop(key, None)
+                    if not details:
+                        source.pop("details", None)
+    return payload
+
+
+def render_json(result: QueryResult, *, include_pattern_bodies: bool = False) -> str:
+    payload = result.to_json()
+    if not include_pattern_bodies:
+        payload = _strip_detail_keys(payload, _DEFAULT_JSON_DETAIL_OMIT)
+    return json.dumps(payload, indent=2, sort_keys=False)
 
 
 def _compact_mapping_json(mapping: Lineage, limit: int) -> JSONDict:
@@ -315,7 +348,12 @@ def _compact_mapping_json(mapping: Lineage, limit: int) -> JSONDict:
     return out
 
 
-def render_compact_json(result: QueryResult, *, limit: int = COMPACT_JSON_SAMPLE_LIMIT) -> str:
+def render_compact_json(
+    result: QueryResult,
+    *,
+    limit: int = COMPACT_JSON_SAMPLE_LIMIT,
+    include_pattern_bodies: bool = False,
+) -> str:
     compact_limit = _clamp_limit(limit, max_limit=COMPACT_JSON_SAMPLE_LIMIT)
     if compact_limit is None:
         compact_limit = COMPACT_JSON_SAMPLE_LIMIT
@@ -349,4 +387,6 @@ def render_compact_json(result: QueryResult, *, limit: int = COMPACT_JSON_SAMPLE
         "diagnostics": [diagnostic.to_json() for diagnostic in diagnostics[:compact_limit]],
         "diagnostics_total": len(diagnostics),
     }
+    if not include_pattern_bodies:
+        _strip_detail_keys(cast(JSONDict, data), _DEFAULT_JSON_DETAIL_OMIT)
     return json.dumps(data, indent=2, sort_keys=False)

--- a/parser_lineage_analyzer/render.py
+++ b/parser_lineage_analyzer/render.py
@@ -295,6 +295,14 @@ _DEFAULT_JSON_DETAIL_OMIT = ("resolved_pattern_body",)
 
 
 def _strip_detail_keys(payload: JSONDict, omit: Sequence[str]) -> JSONDict:
+    """Drop ``omit`` keys from every ``mappings[*].sources[*].details`` dict.
+
+    **Mutates ``payload`` in place** and returns it for call-site convenience.
+    Both callers (:func:`render_json`, :func:`render_compact_json`) construct
+    a fresh payload via ``QueryResult.to_json`` / inline-built dicts before
+    handing it here, so the in-place mutation is safe today; if a future
+    caller passes a payload it wants to keep intact, deep-copy it first.
+    """
     if not omit:
         return payload
     mappings = payload.get("mappings")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ parser_lineage_analyzer = [
 
 [tool.setuptools.exclude-package-data]
 "parser_lineage_analyzer._native" = ["*.c", "*.pyx"]
+# The `grok_patterns/*` glob in [tool.setuptools.package-data] above pulls in
+# every file under that directory — including any `__pycache__/*.pyc` left
+# behind by a prior editable install. Setuptools applies these excludes after
+# the package-data globs, so this strips bytecode out of the wheel without
+# having to enumerate each grok pattern by hand.
+parser_lineage_analyzer = ["**/__pycache__/*", "**/*.pyc", "**/*.pyo"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -10,27 +9,6 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-
-# CI-tunable wall-clock slack multiplier for performance tests. Default is
-# 1.0 (no behavior change on developer machines); slow CI runners can
-# export ``PERF_SLOW_FACTOR=5`` to widen every elapsed-vs-budget assert
-# in ``test_performance_scaling.py`` and ``test_benchmark_smoke.py``
-# without editing the test files. Tests pre-multiply their literal
-# budgets by this constant at module import time, so set the variable
-# before pytest starts. See ``docs/performance-budgets.md`` for guidance
-# on when to bump this versus when a regression has actually landed.
-def _perf_slow_factor() -> float:
-    raw = os.environ.get("PERF_SLOW_FACTOR")
-    if not raw:
-        return 1.0
-    try:
-        value = float(raw)
-    except ValueError:
-        return 1.0
-    return value if value > 0 else 1.0
-
-
-PERF_SLOW_FACTOR: float = _perf_slow_factor()
 
 try:
     from hypothesis import HealthCheck, settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+# CI-tunable wall-clock slack multiplier for performance tests. Default is
+# 1.0 (no behavior change on developer machines); slow CI runners can
+# export ``PERF_SLOW_FACTOR=5`` to widen every elapsed-vs-budget assert
+# in ``test_performance_scaling.py`` and ``test_benchmark_smoke.py``
+# without editing the test files. Tests pre-multiply their literal
+# budgets by this constant at module import time, so set the variable
+# before pytest starts. See ``docs/performance-budgets.md`` for guidance
+# on when to bump this versus when a regression has actually landed.
+def _perf_slow_factor() -> float:
+    raw = os.environ.get("PERF_SLOW_FACTOR")
+    if not raw:
+        return 1.0
+    try:
+        value = float(raw)
+    except ValueError:
+        return 1.0
+    return value if value > 0 else 1.0
+
+
+PERF_SLOW_FACTOR: float = _perf_slow_factor()
 
 try:
     from hypothesis import HealthCheck, settings

--- a/tests/perf_budgets.py
+++ b/tests/perf_budgets.py
@@ -1,0 +1,34 @@
+"""CI-tunable wall-clock slack multiplier for performance tests.
+
+This module is the canonical source for ``PERF_SLOW_FACTOR``. Tests that
+need it (``test_performance_scaling.py``, ``test_benchmark_smoke.py``,
+the ReDoS budget assertion in ``test_cli_and_public_model.py``) import
+from here rather than from ``conftest.py`` — importing ``conftest`` as a
+regular module re-runs its top-level side effects (sys.path mutation,
+Hypothesis profile registration) under a different module name than the
+one pytest loaded, which is brittle.
+
+Default is ``1.0`` (no behavior change on developer machines). Slow CI
+runners can export ``PERF_SLOW_FACTOR=5`` to widen every elapsed-vs-
+budget assert without editing the test files. Tests pre-multiply their
+literal budgets by this constant at module import time, so set the
+variable before pytest starts.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _perf_slow_factor() -> float:
+    raw = os.environ.get("PERF_SLOW_FACTOR")
+    if not raw:
+        return 1.0
+    try:
+        value = float(raw)
+    except ValueError:
+        return 1.0
+    return value if value > 0 else 1.0
+
+
+PERF_SLOW_FACTOR: float = _perf_slow_factor()

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts import benchmark_native_modes
-from tests.conftest import PERF_SLOW_FACTOR
+from tests.perf_budgets import PERF_SLOW_FACTOR
 from tests.test_performance_scaling import (
     _analysis_seconds,
     _hot_branch_append_parser,
@@ -20,7 +20,7 @@ from tests.test_performance_scaling import (
 
 # Wall-clock budgets are pre-multiplied by ``PERF_SLOW_FACTOR`` (default
 # 1.0; CI can export ``PERF_SLOW_FACTOR=N`` to widen the wall budgets
-# without editing this file). See ``tests/conftest.py``.
+# without editing this file). See ``tests/perf_budgets.py``.
 SMOKE_BUDGET_SECONDS = 10.0 * PERF_SLOW_FACTOR
 
 

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts import benchmark_native_modes
+from tests.conftest import PERF_SLOW_FACTOR
 from tests.test_performance_scaling import (
     _analysis_seconds,
     _hot_branch_append_parser,
@@ -17,7 +18,10 @@ from tests.test_performance_scaling import (
     _repeated_append_parser,
 )
 
-SMOKE_BUDGET_SECONDS = 10.0
+# Wall-clock budgets are pre-multiplied by ``PERF_SLOW_FACTOR`` (default
+# 1.0; CI can export ``PERF_SLOW_FACTOR=N`` to widen the wall budgets
+# without editing this file). See ``tests/conftest.py``.
+SMOKE_BUDGET_SECONDS = 10.0 * PERF_SLOW_FACTOR
 
 
 @pytest.mark.parametrize(
@@ -84,7 +88,7 @@ def test_native_modes_benchmark_fails_cleanly_when_runner_times_out(monkeypatch,
 # sub-millisecond; the budget below is wide enough for the slowest
 # macos-26 / windows-2022 runners we've observed, narrow enough to flag
 # a genuine order-of-magnitude regression.
-GROK_RESOLVER_BUDGET_SECONDS = 0.500
+GROK_RESOLVER_BUDGET_SECONDS = 0.500 * PERF_SLOW_FACTOR
 
 
 def test_grok_resolver_cold_plus_cached_within_budget(monkeypatch) -> None:

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -213,7 +213,15 @@ def test_cli_list_text_reports_empty_state(tmp_path, capsys):
     assert capsys.readouterr().out == "No UDM fields found.\n"
 
     assert main([str(parser_file), "--list", "--json"]) == 0
-    assert json.loads(capsys.readouterr().out) == {"udm_fields": [], "udm_fields_total": 0}
+    assert json.loads(capsys.readouterr().out) == {
+        "udm_fields": [],
+        "udm_fields_total": 0,
+        "output_anchors": [],
+        "warnings": [],
+        "unsupported": [],
+        "structured_warnings": [],
+        "diagnostics": [],
+    }
 
 
 def test_cli_rejects_json_with_compact_json(tmp_path, capsys):
@@ -927,3 +935,219 @@ def test_legacy_status_alias_is_not_exported():
     assert "Status" not in parser_lineage_analyzer.__all__
     with pytest.raises(AttributeError):
         parser_lineage_analyzer.Status  # noqa: B018  # attribute access asserts removal
+
+
+def test_cli_module_does_not_eagerly_import_analyzer_or_render():
+    """Importing only ``parser_lineage_analyzer.cli`` must not pull in the
+    heavy analyzer/render/model dependency tree (pydantic, lark, native
+    extensions). ``--help`` and ``--version`` rely on this to keep cold
+    startup under ~50ms; a regression here turns those subcommands into
+    multi-hundred-millisecond invocations.
+    """
+    import subprocess
+
+    # Run in a fresh interpreter so import-cache from earlier tests doesn't
+    # contaminate the result.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, parser_lineage_analyzer.cli;"
+            "missing = [m for m in ('parser_lineage_analyzer.analyzer',"
+            " 'parser_lineage_analyzer.render', 'parser_lineage_analyzer.model',"
+            " 'pydantic') if m in sys.modules];"
+            "print('|'.join(missing))",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", f"cli imports must stay lazy; eager loads detected: {result.stdout.strip()}"
+
+
+def test_cli_json_emits_stable_key_set_when_empty(tmp_path, capsys):
+    """``--json`` must always emit ``output_anchors``, ``unsupported``,
+    ``warnings``, ``structured_warnings``, ``diagnostics`` (as ``[]`` when
+    empty) so downstream consumers don't need conditional ``.get()`` reads.
+    ``*_total`` counters remain compact-only.
+    """
+    parser_file = _write_parser(tmp_path)
+    assert main([str(parser_file), "target.ip", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    for key in ("output_anchors", "unsupported", "warnings", "structured_warnings", "diagnostics"):
+        assert key in payload, f"--json missing stable key: {key}"
+    # No sampling occurred → ``*_total`` counters stay out of plain --json.
+    assert "unsupported_total" not in payload
+    assert "warnings_total" not in payload
+
+
+def test_cli_json_and_compact_json_share_stable_keys(tmp_path, capsys):
+    parser_file = _write_parser(tmp_path)
+    assert main([str(parser_file), "target.ip", "--json"]) == 0
+    plain = json.loads(capsys.readouterr().out)
+    assert main([str(parser_file), "target.ip", "--compact-json"]) == 0
+    compact = json.loads(capsys.readouterr().out)
+    shared = {"output_anchors", "unsupported", "warnings", "structured_warnings", "diagnostics"}
+    assert shared.issubset(plain.keys())
+    assert shared.issubset(compact.keys())
+
+
+def test_cli_json_omits_resolved_pattern_body_by_default(tmp_path, capsys):
+    """The 1.3 KB grok pattern body bloats default JSON for downstream
+    consumers piping to ``jq | head``. ``resolved_pattern_name`` is always
+    preserved so consumers can join against an external pattern library;
+    ``--include-pattern-bodies`` opts back in to the body."""
+    code = r"""
+filter {
+  grok { match => { "message" => "%{IP:dstAddr}" } }
+  mutate { replace => { "event.idm.read_only_udm.target.ip" => "%{dstAddr}" } }
+  mutate { merge => { "@output" => "event" } }
+}
+"""
+    parser_file = _write_parser(tmp_path, code)
+
+    assert main([str(parser_file), "target.ip", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload)
+    assert "resolved_pattern_body" not in serialized
+    assert "resolved_pattern_name" in serialized
+
+    assert main([str(parser_file), "target.ip", "--json", "--include-pattern-bodies"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload)
+    assert "resolved_pattern_body" in serialized
+    assert "resolved_pattern_name" in serialized
+
+
+def test_cli_warning_text_uses_single_backslash_repr(tmp_path, capsys):
+    """The shipped fixture has ``\\d`` (single-escape, regex literal-backslash
+    + ``d``); the warning constructor wraps that with ``!r``, doubling each
+    backslash a second time. The CLI must un-double that doubling so users
+    see the regex they wrote."""
+    examples = Path(__file__).resolve().parents[1] / "examples" / "conditional_parser.cbn"
+    assert main([str(examples), "security_result.action"]) == 0
+    out = capsys.readouterr().out
+    assert "Warnings:" in out
+    # The pattern as the user wrote it has exactly two backslashes per
+    # metachar; the over-escape from ``!r`` would produce four.
+    assert "'\\\\d+\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+'" in out
+    assert "'\\\\\\\\d+" not in out
+
+
+def test_quoted_over_escape_regex_terminates_on_adversarial_input():
+    """``_QUOTED_OVER_ESCAPE`` previously had unbounded inner repetitions
+    (``(?:[^'\\\\]|\\\\.)*``) which catastrophic-backtracks on input that
+    lacks a closing quote. The bounded variant (``{0,1024}``) must
+    fail-match in milliseconds — not seconds — on a >1KB adversarial
+    input. Each warning-rendered quoted span is upstream-bounded by
+    ``MAX_REGEX_BODY_BYTES = 512`` so 1024-per-side covers the cap with
+    slack.
+    """
+    import time
+
+    from parser_lineage_analyzer.cli import _QUOTED_OVER_ESCAPE
+
+    # 1024-char adversarial input: alternating literal/escape chunks
+    # with NO closing quote, so the regex is forced to backtrack.
+    adversarial = "'" + ("a\\\\a\\\\" * 200) + "X"
+    start = time.monotonic()
+    match = _QUOTED_OVER_ESCAPE.search(adversarial)
+    elapsed_ms = (time.monotonic() - start) * 1000.0
+    # The pattern can't match (no closing quote); the asserted contract
+    # is that fail-match takes wall-clock milliseconds, not seconds.
+    assert match is None
+    assert elapsed_ms < 50.0, f"_QUOTED_OVER_ESCAPE took {elapsed_ms:.1f}ms on adversarial input"
+
+    # Sanity: normal inputs still match correctly under the bounded form.
+    normal = "warning: pattern '\\\\d+' is over-escaped"
+    normal_match = _QUOTED_OVER_ESCAPE.search(normal)
+    assert normal_match is not None
+    assert normal_match.group(1) == "\\\\d+"
+
+
+def test_cli_list_json_emits_stable_top_level_keys(tmp_path, capsys):
+    """``--list --json`` must emit ``output_anchors``, ``warnings``,
+    ``unsupported``, ``structured_warnings``, and ``diagnostics`` as ``[]``
+    (alongside the pre-existing ``udm_fields``/``udm_fields_total``) so
+    cross-mode JSON consumers see the same top-level shape regardless of
+    which mode produced the document. ``--list`` carries no per-query
+    data, so the five arrays are always empty — but stable shape matters
+    more than parsimony for ``jq '.warnings | length'`` and similar."""
+    parser_file = _write_parser(tmp_path)
+    assert main([str(parser_file), "--list", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    for key in (
+        "udm_fields",
+        "udm_fields_total",
+        "output_anchors",
+        "warnings",
+        "unsupported",
+        "structured_warnings",
+        "diagnostics",
+    ):
+        assert key in payload, f"--list --json document missing top-level {key!r}"
+    assert payload["output_anchors"] == []
+    assert payload["warnings"] == []
+    assert payload["unsupported"] == []
+    assert payload["structured_warnings"] == []
+    assert payload["diagnostics"] == []
+
+
+def test_cli_strict_json_embeds_strict_failure_key(tmp_path, capsys):
+    """``--strict --json`` must not require stderr scraping: the same
+    summary that's printed to stderr is mirrored as a top-level
+    ``strict_failure`` object on the JSON document."""
+    code = r"""
+filter {
+  mutate { replace => { "event.idm.read_only_udm.additional.fields.%{k}" => "%{missing_value}" } }
+  mutate { merge => { "@output" => "event" } }
+}
+"""
+    parser_file = _write_parser(tmp_path, code)
+    assert main([str(parser_file), "additional.fields.foo", "--json", "--strict"]) == 3
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    failure = payload.get("strict_failure")
+    assert failure is not None
+    assert failure["status"] == "dynamic"
+    assert failure["warnings"] >= 1
+    # Stderr line is preserved unchanged for back-compat with non-JSON
+    # consumers.
+    assert "strict:" in captured.err
+
+
+def test_cli_compact_summary_always_shows_taint_counts_heading(tmp_path, capsys):
+    """``--compact-summary`` must emit the ``Taint counts by code:`` heading
+    (with ``(none)`` when empty) so users discover the field exists."""
+    parser_file = _write_parser(tmp_path)
+    assert main([str(parser_file), "--compact-summary"]) == 0
+    out = capsys.readouterr().out
+    assert "Taint counts by code:" in out
+    assert "(none)" in out
+
+
+def test_cli_strict_help_text_disambiguates_warning_levels():
+    from parser_lineage_analyzer.cli import build_arg_parser
+
+    help_text = build_arg_parser().format_help()
+    # argparse may wrap long lines; collapse whitespace before asserting so
+    # ``query-\n  level`` still passes.
+    flat = " ".join(help_text.split())
+    # The disambiguated help string must mention BOTH parser-level and
+    # query-level gates so users know which conditions trip exit 3.
+    assert "parser-level" in flat
+    assert "query-level" in flat
+
+
+def test_readme_documents_new_cli_flags():
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+    for flag in (
+        "--grok-patterns-dir",
+        "--plugin-signatures",
+        "--plugin-signatures-dir",
+        "--include-pattern-bodies",
+        "--version",
+    ):
+        assert flag in readme, f"README CLI flag table missing: {flag}"
+    assert "NO_COLOR" in readme
+    assert "ASCII-aware only" in readme

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -1046,6 +1046,7 @@ def test_quoted_over_escape_regex_terminates_on_adversarial_input():
     import time
 
     from parser_lineage_analyzer.cli import _QUOTED_OVER_ESCAPE
+    from tests.perf_budgets import PERF_SLOW_FACTOR
 
     # 1024-char adversarial input: alternating literal/escape chunks
     # with NO closing quote, so the regex is forced to backtrack.
@@ -1055,42 +1056,19 @@ def test_quoted_over_escape_regex_terminates_on_adversarial_input():
     elapsed_ms = (time.monotonic() - start) * 1000.0
     # The pattern can't match (no closing quote); the asserted contract
     # is that fail-match takes wall-clock milliseconds, not seconds.
+    # Scale the budget by ``PERF_SLOW_FACTOR`` so coverage runs, ARM
+    # emulation, and contended CI runners don't flake on this gate.
     assert match is None
-    assert elapsed_ms < 50.0, f"_QUOTED_OVER_ESCAPE took {elapsed_ms:.1f}ms on adversarial input"
+    budget_ms = 50.0 * PERF_SLOW_FACTOR
+    assert elapsed_ms < budget_ms, (
+        f"_QUOTED_OVER_ESCAPE took {elapsed_ms:.1f}ms on adversarial input (budget {budget_ms:.1f}ms)"
+    )
 
     # Sanity: normal inputs still match correctly under the bounded form.
     normal = "warning: pattern '\\\\d+' is over-escaped"
     normal_match = _QUOTED_OVER_ESCAPE.search(normal)
     assert normal_match is not None
     assert normal_match.group(1) == "\\\\d+"
-
-
-def test_cli_list_json_emits_stable_top_level_keys(tmp_path, capsys):
-    """``--list --json`` must emit ``output_anchors``, ``warnings``,
-    ``unsupported``, ``structured_warnings``, and ``diagnostics`` as ``[]``
-    (alongside the pre-existing ``udm_fields``/``udm_fields_total``) so
-    cross-mode JSON consumers see the same top-level shape regardless of
-    which mode produced the document. ``--list`` carries no per-query
-    data, so the five arrays are always empty — but stable shape matters
-    more than parsimony for ``jq '.warnings | length'`` and similar."""
-    parser_file = _write_parser(tmp_path)
-    assert main([str(parser_file), "--list", "--json"]) == 0
-    payload = json.loads(capsys.readouterr().out)
-    for key in (
-        "udm_fields",
-        "udm_fields_total",
-        "output_anchors",
-        "warnings",
-        "unsupported",
-        "structured_warnings",
-        "diagnostics",
-    ):
-        assert key in payload, f"--list --json document missing top-level {key!r}"
-    assert payload["output_anchors"] == []
-    assert payload["warnings"] == []
-    assert payload["unsupported"] == []
-    assert payload["structured_warnings"] == []
-    assert payload["diagnostics"] == []
 
 
 def test_cli_strict_json_embeds_strict_failure_key(tmp_path, capsys):
@@ -1113,6 +1091,51 @@ filter {
     assert failure["warnings"] >= 1
     # Stderr line is preserved unchanged for back-compat with non-JSON
     # consumers.
+    assert "strict:" in captured.err
+
+
+def test_cli_strict_summary_json_embeds_strict_failure_key(tmp_path, capsys):
+    """``--summary --json --strict`` must mirror the strict failure
+    object inside the JSON document so machine consumers don't have to
+    scrape stderr — the same contract query mode already provides."""
+    code = r"""
+filter {
+  mutate { replace => { "event.idm.read_only_udm.additional.fields.%{k}" => "%{missing_value}" } }
+  mutate { merge => { "@output" => "event" } }
+}
+"""
+    parser_file = _write_parser(tmp_path, code)
+    assert main([str(parser_file), "--summary", "--json", "--strict"]) == 3
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    failure = payload.get("strict_failure")
+    assert failure is not None
+    assert failure["warnings"] >= 1
+    assert "strict:" in failure["message"]
+    # Stderr line preserved.
+    assert "strict:" in captured.err
+
+
+def test_cli_strict_list_json_embeds_strict_failure_key(tmp_path, capsys):
+    """``--list --json --strict`` must mirror the strict failure object
+    in the JSON document for the same reason as summary mode."""
+    code = r"""
+filter {
+  mutate { replace => { "event.idm.read_only_udm.additional.fields.%{k}" => "%{missing_value}" } }
+  mutate { merge => { "@output" => "event" } }
+}
+"""
+    parser_file = _write_parser(tmp_path, code)
+    assert main([str(parser_file), "--list", "--json", "--strict"]) == 3
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    failure = payload.get("strict_failure")
+    assert failure is not None
+    assert failure["warnings"] >= 1
+    assert "strict:" in failure["message"]
+    # Stable cross-mode shape is preserved alongside the new key.
+    for key in ("udm_fields", "udm_fields_total", "output_anchors", "warnings"):
+        assert key in payload
     assert "strict:" in captured.err
 
 

--- a/tests/test_grok_patterns.py
+++ b/tests/test_grok_patterns.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from parser_lineage_analyzer._grok_patterns import (
     MAX_EXPANDED_BODY_BYTES,
     MAX_GROK_RECURSION_DEPTH,
@@ -61,6 +63,21 @@ class TestBundledLibrary:
             if body is None:
                 continue  # pattern hit a budget bound; that's also sound
             assert "%{" not in body, f"{name} expansion still contains %{{...}}: {body[:60]}..."
+
+    def test_uri_expands_within_budget(self) -> None:
+        # The module's recursion-depth comment claims the deepest chain in
+        # the upstream legacy library tops out around URI's 5-layer fan-in
+        # (URIPROTO/USER/URIHOST/URIPATH/...). Pin that as a positive
+        # assertion: ``expand_pattern("URI")`` must return a non-``None``
+        # body so the bundled library — and the comment's depth claim —
+        # cannot silently regress past either the depth bound or
+        # ``MAX_EXPANDED_BODY_BYTES``.
+        body = expand_pattern("URI")
+        assert body is not None, (
+            "URI no longer expands — depth or byte budget regressed; if intentional, "
+            "update _grok_patterns.py:27-30 and remove this assertion."
+        )
+        assert "%{" not in body
 
 
 class TestExpansionFailureModes:
@@ -205,6 +222,121 @@ class TestLoadLibraryFromPaths:
         # tolerates missing paths by returning an empty library.
         lib = load_library_from_paths([tmp_path / "does_not_exist"])
         assert len(lib) == 0
+
+
+class TestLoadLibraryFromPathsSafety:
+    """Loader robustness: byte cap and symlink containment."""
+
+    def test_explicit_oversize_file_raises_value_error(self, tmp_path: Path) -> None:
+        # An explicit file argument that exceeds the per-file byte cap
+        # surfaces as a loud ``ValueError`` so a typo or wrong path
+        # doesn't silently produce an empty library.
+        from parser_lineage_analyzer._grok_patterns import MAX_PATTERN_FILE_BYTES
+
+        oversize = tmp_path / "huge"
+        # 2 MiB of pattern-shaped lines (well past the 1 MiB cap).
+        oversize.write_bytes(b"FOO foo\n" * ((2 * MAX_PATTERN_FILE_BYTES) // 8))
+        with pytest.raises(ValueError, match="exceeds .* bytes"):
+            load_library_from_paths([oversize])
+
+    def test_directory_oversize_file_silently_skipped(self, tmp_path: Path) -> None:
+        # When walking a directory, oversize files are silently skipped
+        # (matches the silent-drop convention for malformed lines).
+        # Sibling files that are within the cap still load.
+        from parser_lineage_analyzer._grok_patterns import MAX_PATTERN_FILE_BYTES
+
+        big = tmp_path / "big"
+        big.write_bytes(b"BIG big\n" * ((2 * MAX_PATTERN_FILE_BYTES) // 8))
+        small = tmp_path / "small"
+        small.write_text("SMALL small\n", encoding="utf-8")
+        lib = load_library_from_paths([tmp_path])
+        # Big was silently skipped; small still loads.
+        assert "BIG" not in lib
+        assert "SMALL" in lib
+        assert expand_pattern("SMALL", lib) == "small"
+
+    def test_in_directory_symlink_is_followed(self, tmp_path: Path) -> None:
+        # Symlinks pointing inside the same directory must still be
+        # followed — the safety bar is "no escape", not "no symlinks".
+        target = tmp_path / "real"
+        target.write_text("VIA_LINK via_link\n", encoding="utf-8")
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - filesystem-specific
+            pytest.skip("symlinks unavailable on this filesystem")
+        lib = load_library_from_paths([tmp_path])
+        # Both the original file and the symlink resolve to the same
+        # pattern definitions.
+        assert "VIA_LINK" in lib
+        assert expand_pattern("VIA_LINK", lib) == "via_link"
+
+    def test_outside_directory_symlink_is_skipped(self, tmp_path: Path) -> None:
+        # A symlink whose resolved target sits outside the configured
+        # directory is skipped — a configured patterns dir shouldn't
+        # silently pull pattern data from elsewhere on the filesystem
+        # just because someone dropped a symlink in.
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        outside_file = outside_dir / "secret"
+        outside_file.write_text("SECRET secret\n", encoding="utf-8")
+
+        patterns_dir = tmp_path / "patterns"
+        patterns_dir.mkdir()
+        # Friendly local file that should still load.
+        (patterns_dir / "ok").write_text("OK ok\n", encoding="utf-8")
+        # Escaping symlink: should be skipped.
+        link = patterns_dir / "escape_link"
+        try:
+            link.symlink_to(outside_file)
+        except (OSError, NotImplementedError):  # pragma: no cover - filesystem-specific
+            pytest.skip("symlinks unavailable on this filesystem")
+
+        lib = load_library_from_paths([patterns_dir])
+        assert "OK" in lib
+        # The escaping symlink's target was not loaded.
+        assert "SECRET" not in lib
+
+    def test_case_insensitive_filesystem_follows_in_dir_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On macOS APFS / Windows NTFS, ``Path.is_relative_to`` does
+        case-sensitive string equality even though the underlying lookup
+        folds case. The fix in ``_path_is_within`` routes both sides
+        through ``os.path.normcase`` so a case-mismatched directory
+        argument doesn't false-reject an in-dir symlink. Mirrors the
+        ``test_load_directory_case_insensitive_filesystem_follows_in_dir_symlink``
+        test in the plugin-signatures suite — the two loaders share the
+        same containment policy.
+        """
+        import os
+
+        from parser_lineage_analyzer._grok_patterns import _path_is_within
+
+        monkeypatch.setattr(os.path, "normcase", lambda p: p.casefold())
+        patterns_dir = tmp_path / "Patterns"
+        patterns_dir.mkdir()
+        target = patterns_dir / "real"
+        target.write_text("VIA_LINK via_link\n", encoding="utf-8")
+        link = patterns_dir / "link"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):  # pragma: no cover - filesystem-specific
+            pytest.skip("symlinks unavailable on this filesystem")
+
+        # Configured-directory argument differs only in case from the
+        # resolved target's parent. Without ``_path_is_within`` this
+        # would mis-classify the in-dir symlink as outward.
+        case_mismatched = tmp_path / "patterns"
+        resolved_target = link.resolve()
+        assert _path_is_within(resolved_target, case_mismatched) is True
+        # Sanity: a genuinely-outside path is still rejected even with
+        # casefold normalization.
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        outside_file = outside / "secret"
+        outside_file.write_text("SECRET secret\n", encoding="utf-8")
+        assert _path_is_within(outside_file, case_mismatched) is False
 
 
 class TestParserIntegration:

--- a/tests/test_grok_patterns.py
+++ b/tests/test_grok_patterns.py
@@ -302,16 +302,17 @@ class TestLoadLibraryFromPathsSafety:
     ) -> None:
         """On macOS APFS / Windows NTFS, ``Path.is_relative_to`` does
         case-sensitive string equality even though the underlying lookup
-        folds case. The fix in ``_path_is_within`` routes both sides
-        through ``os.path.normcase`` so a case-mismatched directory
-        argument doesn't false-reject an in-dir symlink. Mirrors the
+        folds case. The shared ``path_is_within`` helper (in
+        ``_path_safety``) routes both sides through ``os.path.normcase``
+        so a case-mismatched directory argument doesn't false-reject an
+        in-dir symlink. Mirrors the
         ``test_load_directory_case_insensitive_filesystem_follows_in_dir_symlink``
         test in the plugin-signatures suite — the two loaders share the
         same containment policy.
         """
         import os
 
-        from parser_lineage_analyzer._grok_patterns import _path_is_within
+        from parser_lineage_analyzer._path_safety import path_is_within
 
         monkeypatch.setattr(os.path, "normcase", lambda p: p.casefold())
         patterns_dir = tmp_path / "Patterns"
@@ -325,18 +326,18 @@ class TestLoadLibraryFromPathsSafety:
             pytest.skip("symlinks unavailable on this filesystem")
 
         # Configured-directory argument differs only in case from the
-        # resolved target's parent. Without ``_path_is_within`` this
+        # resolved target's parent. Without ``path_is_within`` this
         # would mis-classify the in-dir symlink as outward.
         case_mismatched = tmp_path / "patterns"
         resolved_target = link.resolve()
-        assert _path_is_within(resolved_target, case_mismatched) is True
+        assert path_is_within(resolved_target, case_mismatched) is True
         # Sanity: a genuinely-outside path is still rejected even with
         # casefold normalization.
         outside = tmp_path / "elsewhere"
         outside.mkdir()
         outside_file = outside / "secret"
         outside_file.write_text("SECRET secret\n", encoding="utf-8")
-        assert _path_is_within(outside_file, case_mismatched) is False
+        assert path_is_within(outside_file, case_mismatched) is False
 
 
 class TestParserIntegration:

--- a/tests/test_implicit_path_conditions.py
+++ b/tests/test_implicit_path_conditions.py
@@ -82,9 +82,11 @@ class TestSynthesizerRoundTrip:
         extracted = extract_regex_literal(synthesized)
         assert extracted is not None, f"failed to parse synthesized condition: {synthesized!r}"
         assert getattr(extracted, "is_match", True) is True
-        # The token reference round-trips. ``extract_regex_literal``
-        # preserves the bracket form as it appears in the source.
-        assert extracted.field in {"token", "[token]"}
+        # The token reference round-trips. The synthesizer always emits
+        # the bracketed form (``[token]``); ``extract_regex_literal``
+        # preserves the bracket form as it appears in the source, so the
+        # round-trip is bracket-exact.
+        assert extracted.field == "[token]"
 
     def test_synthesizer_rejects_oversize_body(self) -> None:
         oversize = "a" * (_MAX_IMPLICIT_GROK_BODY_BYTES + 1)
@@ -393,6 +395,88 @@ class TestCrossFeatureWithF1NegMatch:
         expressions = sorted(m.expression for m in result.mappings)
         assert expressions == ["HTTPS", "OTHER"]
         assert "unreachable_branch" not in _summary_codes(parser)
+
+    def test_regrok_with_oversize_body_invalidates_prior_constraint(self) -> None:
+        # Regression for v0.1.0 release-hardening fix: a re-grok whose
+        # resolved body exceeds ``MAX_REGEX_BODY_BYTES`` (synthesis
+        # returns ``None``) must still invalidate the prior implicit
+        # constraint. Otherwise a literal that contradicts the *first*
+        # grok's shape gets falsely flagged unreachable, even though the
+        # *second* grok overwrote the runtime value with something
+        # whose shape we can no longer prove.
+        #
+        # Repro: grok #1 captures ``%{INT:tok}`` (~19 bytes — synthesis
+        # succeeds, prior implicit constraint is ``[tok] =~ /(?:[+-]?(?:[0-9]+))/``).
+        # Grok #2 captures ``%{IPV6:tok}`` (1071 bytes — exceeds the
+        # 512-byte algebra cap, synthesis returns ``None``). The if-branch
+        # tests ``[tok] == "::1"`` — a valid IPv6 literal that does NOT
+        # match INT. Pre-fix: stale INT constraint persists, "::1"
+        # contradicts ``[tok] =~ /(?:[+-]?(?:[0-9]+))/``, branch wrongly
+        # marked unreachable. Post-fix: invalidation runs unconditionally,
+        # branch stays reachable.
+        from parser_lineage_analyzer._grok_patterns import bundled_library, expand_pattern
+
+        ipv6_body = expand_pattern("IPV6", bundled_library())
+        assert ipv6_body is not None
+        # Sanity: the test only exercises the bug-window if IPV6 is in
+        # the 513..8192 byte range. If a future bundle change resizes
+        # it under the cap, switch to a different pattern.
+        from parser_lineage_analyzer._regex_algebra import MAX_REGEX_BODY_BYTES
+
+        assert len(ipv6_body.encode("utf-8")) > MAX_REGEX_BODY_BYTES, (
+            "test fixture invariant: IPV6 must exceed the algebra body cap"
+        )
+
+        code = """
+        filter {
+          grok { match => { "a" => "%{INT:tok}" } }
+          grok { match => { "b" => "%{IPV6:tok}" } }
+          if [tok] == "::1" {
+            mutate { replace => { "event.idm.read_only_udm.principal.user.userid" => "IPV6_LIT" } }
+          } else {
+            mutate { replace => { "event.idm.read_only_udm.principal.user.userid" => "OTHER" } }
+          }
+        }
+        """
+        parser = ReverseParser(code)
+        parser.analyze()
+        result = parser.query("principal.user.userid")
+        expressions = sorted(m.expression for m in result.mappings)
+        # The if-branch is reachable: IPV6 grok overwrote ``tok``, the
+        # stale INT constraint must have been dropped, and ``[tok] == "::1"``
+        # is no longer flagged as a contradiction.
+        assert "IPV6_LIT" in expressions, (
+            f"oversize re-grok invalidation regression: expected IPV6_LIT to remain reachable, got {expressions!r}"
+        )
+        assert "OTHER" in expressions
+
+    def test_regrok_with_oversize_body_drops_prior_implicit_for_token(self) -> None:
+        # Companion white-box test: assert the implicit-conditions list
+        # state directly. The end-to-end test above proves the user-visible
+        # behavior; this test pins the contract to ``state.implicit_path_conditions``
+        # so a regression in invalidation surfaces here even if the
+        # downstream contradiction routing changes shape.
+        from parser_lineage_analyzer._grok_patterns import bundled_library, expand_pattern
+        from parser_lineage_analyzer._regex_algebra import MAX_REGEX_BODY_BYTES
+
+        ipv6_body = expand_pattern("IPV6", bundled_library())
+        assert ipv6_body is not None
+        assert len(ipv6_body.encode("utf-8")) > MAX_REGEX_BODY_BYTES
+
+        code = """
+        filter {
+          grok { match => { "a" => "%{INT:tok}" } }
+          grok { match => { "b" => "%{IPV6:tok}" } }
+        }
+        """
+        parser = ReverseParser(code)
+        parser.analyze()
+        # No implicit constraint should remain on ``tok``: the second
+        # grok's body is oversize so synthesis was skipped, but
+        # invalidation still ran and dropped the INT shape constraint.
+        assert not any("[tok]" in cond for cond in parser.state.implicit_path_conditions), (
+            f"oversize re-grok left a stale [tok] constraint: {parser.state.implicit_path_conditions!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_implicit_path_conditions.py
+++ b/tests/test_implicit_path_conditions.py
@@ -478,6 +478,41 @@ class TestCrossFeatureWithF1NegMatch:
             f"oversize re-grok left a stale [tok] constraint: {parser.state.implicit_path_conditions!r}"
         )
 
+    def test_alternation_with_oversize_first_alt_does_not_synthesize_from_second(self) -> None:
+        # Within a *single* grok call, alternation that captures the
+        # same token from multiple branches is disjunctive at runtime:
+        # ``tok`` got its value from whichever alternative matched, not
+        # both. If iter 1 fails synthesis (oversize) and iter 2
+        # succeeds, naïvely adding the iter-2 constraint would falsely
+        # claim ``tok`` always matches the iter-2 shape — but a runtime
+        # value from the iter-1 alternative could violate that. The
+        # ``seen_tokens_this_call`` guard ensures iter 2 sees
+        # ``had_prior=True`` and skips the add (the disjunctive-runtime
+        # drop-both rule).
+        from parser_lineage_analyzer._grok_patterns import bundled_library, expand_pattern
+        from parser_lineage_analyzer._regex_algebra import MAX_REGEX_BODY_BYTES
+
+        ipv6_body = expand_pattern("IPV6", bundled_library())
+        assert ipv6_body is not None
+        assert len(ipv6_body.encode("utf-8")) > MAX_REGEX_BODY_BYTES
+
+        # Single grok call, two alternatives capturing the same token.
+        # IPV6 is oversize (synthesis skipped), INT would otherwise
+        # synthesize a digit-only constraint — but seen_tokens_this_call
+        # suppresses that.
+        code = """
+        filter {
+          grok { match => { "a" => "%{IPV6:tok}|%{INT:tok}" } }
+        }
+        """
+        parser = ReverseParser(code)
+        parser.analyze()
+        assert not any("[tok]" in cond for cond in parser.state.implicit_path_conditions), (
+            "alternation re-grok added a constraint from the second alternative; "
+            "the oversize first alternative should have suppressed it via "
+            f"seen_tokens_this_call. State: {parser.state.implicit_path_conditions!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Mutate propagation: rename / gsub / remove

--- a/tests/test_maximal_cleanup_contracts.py
+++ b/tests/test_maximal_cleanup_contracts.py
@@ -446,15 +446,19 @@ def test_executor_components_have_no_method_collisions():
 
 
 def test_executor_collision_message_includes_both_modules():
-    """Whitebox: the collision-detection loop in ``_analysis_executor`` formats
+    """Whitebox: ``_analysis_executor._compute_collision_messages`` must format
     each finding as
     ``"<method> (<owner_name> from <owner_module>, <new_name> from <new_module>)"``
     so a real collision diagnostic identifies both offending mixins
     unambiguously. Construct two ad-hoc classes with a colliding method
-    name but distinct ``__module__``s, run the same loop, and verify the
-    rendered string includes both module paths in the documented format.
+    name but distinct ``__module__``s, invoke the production helper, and
+    verify the rendered string includes both module paths.
+
+    Invoking the production helper (rather than re-implementing the
+    loop body in the test) means a future drift in the format string
+    fails this test instead of going unnoticed.
     """
-    from parser_lineage_analyzer._analysis_executor import _component_methods
+    from parser_lineage_analyzer._analysis_executor import _compute_collision_messages
 
     class AdHocOwner:
         def colliding_method(self) -> None:
@@ -470,16 +474,7 @@ def test_executor_collision_message_includes_both_modules():
     AdHocOwner.__module__ = "tests.synthetic.module_owner"
     AdHocNewcomer.__module__ = "tests.synthetic.module_newcomer"
 
-    components = (AdHocOwner, AdHocNewcomer)
-    seen_methods: dict[str, tuple[str, str]] = {}
-    collisions: list[str] = []
-    for component in components:
-        for method in _component_methods(component):
-            owner_name, owner_module = seen_methods.setdefault(method, (component.__name__, component.__module__))
-            if owner_name != component.__name__:
-                collisions.append(
-                    f"{method} ({owner_name} from {owner_module}, {component.__name__} from {component.__module__})"
-                )
+    collisions = _compute_collision_messages((AdHocOwner, AdHocNewcomer))
 
     assert collisions == [
         "colliding_method (AdHocOwner from tests.synthetic.module_owner,"

--- a/tests/test_maximal_cleanup_contracts.py
+++ b/tests/test_maximal_cleanup_contracts.py
@@ -488,3 +488,32 @@ def test_executor_collision_message_includes_both_modules():
     assert "AdHocOwner" in rendered
     assert "AdHocNewcomer" in rendered
     assert rendered.startswith("colliding_method (")
+
+
+def test_executor_collision_check_uses_full_owner_identity():
+    """Two mixins from *different modules* but sharing the same class name
+    must still register as a collision. The earlier ``owner_name`` check
+    let same-name-different-module shadowing pass undetected; the
+    contract is now ``(name, module)`` identity equality."""
+    from parser_lineage_analyzer._analysis_executor import _compute_collision_messages
+
+    class Helpers:  # noqa: D401 - synthetic fixture
+        def shared_method(self) -> None:
+            pass
+
+    class Helpers2:  # noqa: D401 - synthetic fixture
+        def shared_method(self) -> None:
+            pass
+
+    # Same class name, different modules — without full-identity comparison
+    # this collision would have been missed.
+    Helpers.__name__ = "Helpers"
+    Helpers2.__name__ = "Helpers"
+    Helpers.__module__ = "tests.synthetic.module_a"
+    Helpers2.__module__ = "tests.synthetic.module_b"
+
+    collisions = _compute_collision_messages((Helpers, Helpers2))
+    assert len(collisions) == 1
+    assert "tests.synthetic.module_a" in collisions[0]
+    assert "tests.synthetic.module_b" in collisions[0]
+    assert collisions[0].startswith("shared_method (")

--- a/tests/test_maximal_cleanup_contracts.py
+++ b/tests/test_maximal_cleanup_contracts.py
@@ -443,3 +443,53 @@ def test_executor_components_have_no_method_collisions():
             assert name not in seen, f"{name} collides between {seen[name]} and {component.__name__}"
             seen[name] = component.__name__
     assert issubclass(AnalysisExecutor, _EXECUTOR_COMPONENTS)
+
+
+def test_executor_collision_message_includes_both_modules():
+    """Whitebox: the collision-detection loop in ``_analysis_executor`` formats
+    each finding as
+    ``"<method> (<owner_name> from <owner_module>, <new_name> from <new_module>)"``
+    so a real collision diagnostic identifies both offending mixins
+    unambiguously. Construct two ad-hoc classes with a colliding method
+    name but distinct ``__module__``s, run the same loop, and verify the
+    rendered string includes both module paths in the documented format.
+    """
+    from parser_lineage_analyzer._analysis_executor import _component_methods
+
+    class AdHocOwner:
+        def colliding_method(self) -> None:
+            pass
+
+    class AdHocNewcomer:
+        def colliding_method(self) -> None:
+            pass
+
+    # Pin distinct synthetic modules so the format string carries two
+    # different ``from <module>`` substrings — a single-module collision
+    # would render the same module twice and the test would still pass.
+    AdHocOwner.__module__ = "tests.synthetic.module_owner"
+    AdHocNewcomer.__module__ = "tests.synthetic.module_newcomer"
+
+    components = (AdHocOwner, AdHocNewcomer)
+    seen_methods: dict[str, tuple[str, str]] = {}
+    collisions: list[str] = []
+    for component in components:
+        for method in _component_methods(component):
+            owner_name, owner_module = seen_methods.setdefault(method, (component.__name__, component.__module__))
+            if owner_name != component.__name__:
+                collisions.append(
+                    f"{method} ({owner_name} from {owner_module}, {component.__name__} from {component.__module__})"
+                )
+
+    assert collisions == [
+        "colliding_method (AdHocOwner from tests.synthetic.module_owner,"
+        " AdHocNewcomer from tests.synthetic.module_newcomer)"
+    ]
+    rendered = collisions[0]
+    # The diagnostic must name BOTH modules — without that detail an
+    # operator can't tell which mixin to renumber.
+    assert "tests.synthetic.module_owner" in rendered
+    assert "tests.synthetic.module_newcomer" in rendered
+    assert "AdHocOwner" in rendered
+    assert "AdHocNewcomer" in rendered
+    assert rendered.startswith("colliding_method (")

--- a/tests/test_performance_scaling.py
+++ b/tests/test_performance_scaling.py
@@ -18,7 +18,7 @@ from parser_lineage_analyzer.config_parser import (
 )
 from parser_lineage_analyzer.model import Lineage, QueryResult, SourceRef, TaintReason, _freeze_details
 from parser_lineage_analyzer.render import render_compact_json, render_text
-from tests.conftest import PERF_SLOW_FACTOR
+from tests.perf_budgets import PERF_SLOW_FACTOR
 
 _NATIVE_DISABLED = os.environ.get("PARSER_LINEAGE_ANALYZER_NO_EXT", "").lower() in {"1", "true", "yes", "on"}
 

--- a/tests/test_performance_scaling.py
+++ b/tests/test_performance_scaling.py
@@ -18,8 +18,20 @@ from parser_lineage_analyzer.config_parser import (
 )
 from parser_lineage_analyzer.model import Lineage, QueryResult, SourceRef, TaintReason, _freeze_details
 from parser_lineage_analyzer.render import render_compact_json, render_text
+from tests.conftest import PERF_SLOW_FACTOR
 
 _NATIVE_DISABLED = os.environ.get("PARSER_LINEAGE_ANALYZER_NO_EXT", "").lower() in {"1", "true", "yes", "on"}
+
+
+def _budget(seconds: float) -> float:
+    """Wall-clock budget multiplied by ``PERF_SLOW_FACTOR``.
+
+    The default factor is 1.0 so production CI sees no behavior change;
+    slow runners can export ``PERF_SLOW_FACTOR=N`` to widen every
+    elapsed-vs-budget assert in this file at once. See
+    ``tests/conftest.py`` for the env-var contract.
+    """
+    return seconds * PERF_SLOW_FACTOR
 
 
 def _compact_summary(parser: ReverseParser) -> CompactAnalysisSummaryDict:
@@ -567,32 +579,32 @@ def _real_slow_3_diagnostic_shape_parser() -> str:
 @pytest.mark.parametrize(("count", "budget"), [(5_000, 5.0), (10_000, 8.0), (20_000, 15.0)])
 def test_independent_conditionals_scale_near_linearly(count: int, budget: float):
     elapsed, parser = _analysis_seconds(_independent_if_parser(count))
-    assert elapsed < budget
+    assert elapsed < _budget(budget)
     assert len(parser.analyze().tokens) == (count * 2) + 1
 
 
 def test_large_mutate_only_parser_avoids_descendant_scan_quadratic_behavior():
     elapsed, parser = _analysis_seconds(_mutate_only_parser(20_000))
-    assert elapsed < 8.0
+    assert elapsed < _budget(8.0)
     assert len(parser.analyze().tokens) == 20_001
 
 
 def test_end_to_end_large_flat_mutates_stays_within_total_budget():
     elapsed, parser = _parse_and_analysis_seconds(_mutate_only_parser(20_000))
-    assert elapsed < 15.0
+    assert elapsed < _budget(15.0)
     assert len(parser.analyze().tokens) == 20_001
 
 
 def test_end_to_end_independent_ifs_stays_within_total_budget():
     elapsed, parser = _parse_and_analysis_seconds(_independent_if_parser(20_000))
-    assert elapsed < 22.0
+    assert elapsed < _budget(22.0)
     assert len(parser.analyze().tokens) == 40_001
 
 
 def test_mega_parser_fixture_stays_fast_end_to_end():
     fixture = Path(__file__).parent / "fixtures" / "test_corpus" / "challenge" / "test_mega_parser_perf_budget.cbn"
     elapsed, parser = _parse_and_analysis_seconds(fixture.read_text(encoding="utf-8"))
-    assert elapsed < 3.0
+    assert elapsed < _budget(3.0)
     assert parser.analyze().tokens
 
 
@@ -603,7 +615,7 @@ def test_scanner_strips_many_trailing_comments_without_mangling_comment_like_bod
     stripped = strip_comments_keep_offsets(code)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert len(stripped) == len(code)
     assert stripped.count("http://example.com/a//b/") == 10_000
     assert stripped.count("//node") == 10_000
@@ -617,14 +629,14 @@ def test_scanner_comment_free_fast_path_returns_original_text_without_full_scan(
     stripped = strip_comments_keep_offsets(code)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.05
+    assert elapsed < _budget(0.05)
     assert stripped is code
 
 
 @pytest.mark.parametrize(("count", "budget"), [(1_000, 3.0), (2_000, 6.0), (5_000, 20.0)])
 def test_drop_guards_scale_with_delta_merge_and_compact_path_conditions(count: int, budget: float):
     elapsed, parser = _analysis_seconds(_drop_guard_parser(count))
-    assert elapsed < budget
+    assert elapsed < _budget(budget)
     result = parser.query(f"additional.fields.k{count - 1}")
     assert any("drop parser may drop events" in warning for warning in result.warnings)
     conditions = list(result.mappings[0].conditions)
@@ -636,7 +648,7 @@ def test_drop_guards_scale_with_delta_merge_and_compact_path_conditions(count: i
 
 def test_standalone_on_error_blocks_use_delta_reconciliation():
     elapsed, parser = _analysis_seconds(_standalone_on_error_parser(1_000))
-    assert elapsed < 4.0
+    assert elapsed < _budget(4.0)
     result = parser.query("additional.fields.err999")
     assert any("on_error" in cond for mapping in result.mappings for cond in mapping.conditions)
     assert any("NOT(on_error)" in cond for mapping in result.mappings for cond in mapping.conditions)
@@ -645,7 +657,7 @@ def test_standalone_on_error_blocks_use_delta_reconciliation():
 @pytest.mark.parametrize(("count", "budget"), [(1_000, 2.0), (2_000, 4.0), (4_000, 8.0)])
 def test_branch_local_extractors_and_anchors_do_not_force_full_token_merge(count: int, budget: float):
     elapsed, parser = _analysis_seconds(_branch_local_metadata_parser(count))
-    assert elapsed < budget
+    assert elapsed < _budget(budget)
     summary = _compact_summary(parser)
     assert summary["json_extractions_total"] == count
     assert summary["output_anchors_total"] == count
@@ -653,13 +665,13 @@ def test_branch_local_extractors_and_anchors_do_not_force_full_token_merge(count
 
 def test_branch_local_metadata_avoids_quadratic_probe_shape():
     elapsed, parser = _analysis_seconds(_branch_local_metadata_parser(4_000, seed_count=0))
-    assert elapsed < 5.0
+    assert elapsed < _budget(5.0)
     assert _compact_summary(parser)["json_extractions_total"] == 4_000
 
 
 def test_dynamic_loop_alternatives_merge_only_loop_deltas():
     elapsed, parser = _analysis_seconds(_dynamic_loop_parser(1_000))
-    assert elapsed < 8.0
+    assert elapsed < _budget(8.0)
     assert "event.idm.read_only_udm.additional.fields.loop999_4" in parser.analyze().tokens
 
 
@@ -686,7 +698,7 @@ def test_nested_static_loop_over_cumulative_fanout_is_summarized_fast():
     elapsed = time.perf_counter() - start
     result = parser.query("additional.fields.combo")
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert summary["warning_counts"]["loop_fanout"] >= 1
     assert summary["taint_counts"]["loop_fanout"] >= 1
     assert result.status == "dynamic"
@@ -701,7 +713,7 @@ def test_nested_dynamic_loop_over_cumulative_fanout_is_summarized_fast():
     elapsed = time.perf_counter() - start
     result = parser.query("additional.fields.cross")
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert summary["warning_counts"]["loop_fanout"] >= 1
     assert summary["taint_counts"]["loop_fanout"] >= 1
     assert result.status == "dynamic"
@@ -715,7 +727,7 @@ def test_real_slow_shape_completes_with_loop_fanout_diagnostics():
     summary = _compact_summary(parser)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 2.0
+    assert elapsed < _budget(2.0)
     assert summary["warning_counts"]["loop_fanout"] >= 2
     assert summary["taint_counts"]["loop_fanout"] >= 2
 
@@ -727,7 +739,7 @@ def test_gsub_transform_fanout_is_summarized_fast():
     elapsed = time.perf_counter() - start
     result = parser.query("additional.fields.posture")
 
-    assert elapsed < 2.0
+    assert elapsed < _budget(2.0)
     assert summary["warning_counts"]["gsub_transform_fanout"] >= 1
     assert summary["taint_counts"]["gsub_transform_fanout"] >= 1
     assert any(
@@ -758,7 +770,7 @@ def test_self_referential_template_chain_is_summarized_fast():
     summary = _compact_summary(parser)
     result = parser.query("target_taxonomy_role")
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert summary["warning_counts"]["template_fanout"] >= 1
     assert any(diagnostic.code == "dynamic_loop_iterable" for diagnostic in result.effective_diagnostics)
 
@@ -767,7 +779,7 @@ def test_same_field_independent_branch_chain_uses_cached_condition_facts():
     elapsed, parser = _analysis_seconds(_same_field_port_chain_parser(250))
     result = parser.query("additional.fields.proto")
 
-    assert elapsed < 3.0
+    assert elapsed < _budget(3.0)
     assert any(diagnostic.code == "branch_lineage_fanout" for diagnostic in result.effective_diagnostics)
 
 
@@ -777,7 +789,7 @@ def test_real_slow_2_shape_completes_with_transform_and_branch_fanout_diagnostic
     summary = _compact_summary(parser)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 5.0
+    assert elapsed < _budget(5.0)
     assert summary["warning_counts"]["gsub_transform_fanout"] >= 1
     assert summary["warning_counts"]["branch_lineage_fanout"] >= 1
     assert summary["warning_counts"]["unresolved_extractor_source"] == 8_000
@@ -797,7 +809,7 @@ def test_literal_collection_merge_over_cap_is_summarized_fast():
     summary = _compact_summary(parser)
     lineages = parser.analyze().tokens["global_threat_feed"]
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert len(lineages) == 1
     assert lineages[0].status == "dynamic"
     assert summary["warning_counts"]["literal_collection_fanout"] == 1
@@ -812,7 +824,7 @@ def test_unresolved_json_extractor_diagnostics_are_coalesced_with_logical_counts
         warning for warning in parser.analyze().structured_warnings if warning.code == "unresolved_extractor_source"
     ]
 
-    assert elapsed < 2.0
+    assert elapsed < _budget(2.0)
     assert len(warnings) <= 129
     assert summary["warning_counts"]["unresolved_extractor_source"] == count
     assert summary["taint_counts"]["unresolved_extractor_source"] == count
@@ -824,7 +836,7 @@ def test_coalesced_extractor_counts_survive_branch_merges():
     elapsed, parser = _analysis_seconds(_branched_unresolved_json_extractor_parser(count_per_branch))
     summary = _compact_summary(parser)
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert summary["warning_counts"]["unresolved_extractor_source"] == count_per_branch * 2
     assert summary["taint_counts"]["unresolved_extractor_source"] == count_per_branch * 2
 
@@ -849,7 +861,7 @@ def test_real_slow_3_shape_combines_template_and_extractor_summarization():
         warning for warning in parser.analyze().structured_warnings if warning.code == "unresolved_extractor_source"
     ]
 
-    assert elapsed < 5.0
+    assert elapsed < _budget(5.0)
     assert len(unresolved_warnings) <= 129
     assert summary["warning_counts"]["template_fanout"] >= 1
     assert summary["warning_counts"]["gsub_transform_fanout"] >= 1
@@ -858,11 +870,11 @@ def test_real_slow_3_shape_combines_template_and_extractor_summarization():
 
 def test_object_merge_and_parent_remove_rename_use_descendant_indexes():
     elapsed, parser = _analysis_seconds(_object_merge_parser(2_000))
-    assert elapsed < 5.0
+    assert elapsed < _budget(5.0)
     assert "event.idm.read_only_udm.additional.fields.obj1999.child" in parser.analyze().tokens
 
     elapsed, parser = _analysis_seconds(_parent_remove_rename_parser(4_000))
-    assert elapsed < 8.0
+    assert elapsed < _budget(8.0)
     state = parser.analyze()
     assert state.tokens["root3999.child"][0].status == "removed"
     assert "keep3999.child" not in state.tokens
@@ -870,26 +882,26 @@ def test_object_merge_and_parent_remove_rename_use_descendant_indexes():
 
 def test_large_extractor_hint_reference_lookup_uses_target_index():
     elapsed, parser = _analysis_seconds(_json_hint_reference_parser(10_000))
-    assert elapsed < 12.0
+    assert elapsed < _budget(12.0)
     result = parser.query("additional.fields.hint9999")
     assert result.mappings
 
 
 def test_interleaved_extractor_hint_index_updates_incrementally():
     elapsed, parser = _analysis_seconds(_interleaved_json_hint_reference_parser(5_000))
-    assert elapsed < 8.0
+    assert elapsed < _budget(8.0)
     assert parser.query("additional.fields.hint4999").mappings
 
 
 def test_deep_extractor_target_hint_chains_are_indexed_by_prefix():
     elapsed, parser = _analysis_seconds(_json_target_chain_parser(1_000))
-    assert elapsed < 2.0
+    assert elapsed < _budget(2.0)
 
     start = time.perf_counter()
     result = parser.query("additional.fields.deep")
     query_elapsed = time.perf_counter() - start
 
-    assert query_elapsed < 0.25
+    assert query_elapsed < _budget(0.25)
     assert len(result.mappings) == 1_000
     # C1 fix: chained json extractions all flow through a single
     # `mutate.replace` (overwrite), so these 1000 mappings represent
@@ -918,7 +930,7 @@ def test_untargeted_extractor_hints_are_coalesced_before_token_inference_fanout(
     hints = state.extractor_hints_for_token("json", "deep.field")
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert len(state.json_extractions) == 5_000
     assert len(hints) == 1
     assert len(tuple(hints[0].parser_locations)) == 128
@@ -926,7 +938,7 @@ def test_untargeted_extractor_hints_are_coalesced_before_token_inference_fanout(
 
 def test_repeated_appends_to_same_token_are_incremental():
     elapsed, parser = _analysis_seconds(_repeated_append_parser(20_000))
-    assert elapsed < 10.0
+    assert elapsed < _budget(10.0)
     result = parser.query("additional.fields.repeat")
     assert len(result.mappings) == 20_000
 
@@ -938,7 +950,7 @@ def test_dynamic_destination_query_uses_template_index_for_unrelated_prefixes():
     start = time.perf_counter()
     miss = parser.query("principal.ip")
     unrelated_elapsed = time.perf_counter() - start
-    assert unrelated_elapsed < 0.25
+    assert unrelated_elapsed < _budget(0.25)
     assert miss.status == "unresolved"
 
     hit = parser.query("additional.fields.anything")
@@ -953,7 +965,7 @@ def test_duplicate_anchors_do_not_multiply_dynamic_query_work():
     result = parser.query("additional.fields.anything")
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert len(result.output_anchors) == 1
     assert len(result.mappings) == 1_000
 
@@ -966,7 +978,7 @@ def test_root_dynamic_templates_use_literal_guard_for_unrelated_query_misses():
     result = parser.query("event.idm.read_only_udm.principal.ip")
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert result.status == "unresolved"
 
 
@@ -974,7 +986,7 @@ def test_destination_template_static_fanout_is_capped_before_materializing_token
     elapsed, parser = _analysis_seconds(_destination_template_fanout_parser(11))
     state = parser.analyze()
 
-    assert elapsed < 1.0
+    assert elapsed < _budget(1.0)
     assert len(state.tokens) < 100
     assert any(diagnostic.code == "template_fanout" for diagnostic in state.diagnostics)
     assert any(warning.code == "dynamic_destination" for warning in state.structured_warnings)
@@ -992,13 +1004,13 @@ def test_unique_output_anchor_queries_use_prefix_index(count: int, budget: float
     result = parser.query("principal.ip")
     elapsed = time.perf_counter() - start
 
-    assert elapsed < budget
+    assert elapsed < _budget(budget)
     assert len(result.output_anchors) == count
 
 
 def test_hot_repeated_branch_appends_do_not_reclone_existing_lineages():
     elapsed, parser = _analysis_seconds(_hot_branch_append_parser(10_000))
-    assert elapsed < 12.0
+    assert elapsed < _budget(12.0)
     result = parser.query("additional.fields.repeat")
     assert len(result.mappings) <= 4_097
     assert any(diagnostic.code == "branch_lineage_fanout" for diagnostic in result.effective_diagnostics)
@@ -1006,7 +1018,7 @@ def test_hot_repeated_branch_appends_do_not_reclone_existing_lineages():
 
 def test_explicit_else_self_rewrite_lineage_doubling_is_capped():
     elapsed, parser = _analysis_seconds(_explicit_else_self_rewrite_parser(16))
-    assert elapsed < 3.0
+    assert elapsed < _budget(3.0)
     result = parser.query("additional.fields.x")
     assert len(result.mappings) == 1
     assert result.mappings[0].status == "conditional"
@@ -1022,7 +1034,7 @@ def test_anchor_conditioned_dynamic_query_is_sampled_in_compact_output():
     elapsed = time.perf_counter() - start
     payload = render_compact_json(result)
 
-    assert elapsed < 2.0
+    assert elapsed < _budget(2.0)
     assert result.total_mappings == 2_000_000
     assert len(result.mappings) <= 50
     assert '"mappings_total": 2000000' in payload
@@ -1113,7 +1125,7 @@ def test_compact_summary_many_static_fields_samples_without_scanning_full_payloa
     summary = _compact_summary(parser)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert summary["udm_fields_total"] == 20_000
     assert len(summary["udm_fields"]) == 50
     assert summary["token_count"] == 20_001
@@ -1127,7 +1139,7 @@ def test_compact_summary_aggregates_high_volume_taints_without_full_payload_grow
     summary = _compact_summary(parser)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert summary["taints_total"] == 6_000
     assert summary["taint_counts"]["dynamic_destination"] == 2_000
     assert summary["taint_counts"]["unresolved_token"] == 4_000
@@ -1170,14 +1182,14 @@ def test_text_render_limits_mapping_taints_without_unbounded_output():
     text = render_text(result, verbose=True, limit=5)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert text.count("dynamic_destination: taint") == 5
     assert "... 1995 more taints omitted" in text
 
 
 def test_large_else_if_chain_remains_fast():
     elapsed, parser = _analysis_seconds(_else_if_chain_parser(4_000))
-    assert elapsed < 5.0
+    assert elapsed < _budget(5.0)
     result = parser.query("security_result.action")
     assert len(result.mappings) == 4_000
 
@@ -1187,7 +1199,7 @@ def test_secops_routing_else_if_chain_uses_sparse_branch_merge(count: int, budge
     if _NATIVE_DISABLED:
         pytest.skip("strict parse+analysis budget requires native scanner/config acceleration")
     elapsed, parser = _parse_and_analysis_seconds(_secops_routing_chain_parser(count))
-    assert elapsed < budget
+    assert elapsed < _budget(budget)
     summary = _compact_summary(parser)
     assert summary["token_count"] == (count * 3) + 18
     assert summary["json_extractions_total"] == 1
@@ -1360,7 +1372,7 @@ def test_nested_array_config_cache_fast_path_scales_and_returns_fresh_values():
         parsed = parse_config(config)
     elapsed = time.perf_counter() - start
 
-    assert elapsed < 0.5
+    assert elapsed < _budget(0.5)
     assert parsed == [("x", [["a", "b"], ["c", ["d", "e"]], ["f", ["g", ["h"]]]])]
     parsed[0][1].append(["polluted"])
     assert parse_config(config) == [("x", [["a", "b"], ["c", ["d", "e"]], ["f", ["g", ["h"]]]])]
@@ -1414,7 +1426,7 @@ def test_with_conditions_long_existing_tuple_uses_set_membership_fast_path():
     # fast path (cached frozenset, O(1) lookup) finishes in tens of ms on
     # fast hardware; budget is loose to absorb noisy CI runners (Windows
     # py3.11 GHA observed ~0.5s; macOS/Linux observed <0.05s).
-    assert elapsed < 1.5
+    assert elapsed < _budget(1.5)
 
 
 def test_analyzer_state_clone_uses_cow_for_inferred_token_caches():
@@ -1457,7 +1469,7 @@ def test_analyzer_state_clone_uses_cow_for_inferred_token_caches():
     # catching a regression to the unconditional eager-copy path, which
     # would balloon to several seconds at this iteration count once the
     # inferred-cache dicts inflate to realistic sizes.
-    assert elapsed < 3.0
+    assert elapsed < _budget(3.0)
 
     # Sanity-check COW semantics: parent state remains untouched even
     # though every clone mutated its view of the inferred caches.
@@ -1548,7 +1560,7 @@ def test_analyzer_state_clone_uses_per_kind_cow_for_extractor_hint_index():
     # 8s budget still catches a regression with 100% margin while absorbing
     # CI variance. Don't tighten this without re-measuring the pre-fix wall
     # on the slowest runner in the matrix.
-    assert elapsed < 8.0
+    assert elapsed < _budget(8.0)
 
     # Sanity-check COW semantics: parent's index is untouched and still sized
     # to the original 1000 hints per kind, while every clone sees 1001 json

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -272,7 +272,10 @@ class TestTomlLoader:
         # Need > 1 MiB total; comment line is 83 bytes.
         repeats = (1024 * 1024 // len(comment)) + 100
         body = comment * repeats + '[ok]\nsemantic_class = "passthrough"\nsource_keys = []\ndest_keys = []\n'
-        f.write_text(body, encoding="utf-8")
+        # ``write_bytes`` rather than ``write_text`` so Windows doesn't
+        # translate ``\n`` -> ``\r\n`` and silently inflate the file size
+        # past the cap we're trying to test.
+        f.write_bytes(body.encode("utf-8"))
         # Sanity-check the test fixture itself is over the cap.
         assert f.stat().st_size > 1024 * 1024
         reg = PluginSignatureRegistry()
@@ -289,7 +292,9 @@ class TestTomlLoader:
         pad = "# " + ("x" * 80) + "\n"
         pad_count = (target - len(prefix)) // len(pad)
         body = prefix + pad * max(0, pad_count)
-        f.write_text(body, encoding="utf-8")
+        # ``write_bytes`` rather than ``write_text`` so Windows doesn't
+        # translate ``\n`` -> ``\r\n`` and inflate the file past the cap.
+        f.write_bytes(body.encode("utf-8"))
         assert f.stat().st_size < 1024 * 1024
         reg = PluginSignatureRegistry()
         reg.load_toml(f)

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -212,6 +212,200 @@ class TestTomlLoader:
         reg.load_directory(tmp_path / "does_not_exist")
         assert len(reg) == 0
 
+    def test_load_toml_malformed_raises_value_error_not_traceback(self, tmp_path: Path) -> None:
+        # Regression for v0.1.0 release hardening: ``tomllib.TOMLDecodeError``
+        # used to escape ``load_toml``. The CLI catches ``(OSError, ValueError)``
+        # so this leaked an uncaught traceback in the user's terminal.
+        # ``load_toml`` now wraps it as a ``ValueError`` with the path in
+        # the message so the CLI's deterministic-diagnostic contract
+        # holds.
+        f = tmp_path / "broken.toml"
+        f.write_text("this is not valid toml = = =\n", encoding="utf-8")
+        reg = PluginSignatureRegistry()
+        with pytest.raises(ValueError) as excinfo:
+            reg.load_toml(f)
+        assert "invalid TOML" in str(excinfo.value)
+        assert str(f) in str(excinfo.value)
+        # And specifically NOT the underlying decode-error type — the
+        # wrapper is the contract.
+        assert "TOMLDecodeError" not in type(excinfo.value).__name__
+
+    def test_load_toml_explicit_name_matching_table_key_succeeds(self, tmp_path: Path) -> None:
+        # Sanity: explicit ``name`` that matches the table key is accepted.
+        # The redundancy is allowed because some users prefer to write it
+        # explicitly; the rejection only fires on *divergent* names.
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            '[my_plugin]\nname = "my_plugin"\nsemantic_class = "passthrough"\n'
+            'source_keys = ["src"]\ndest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        reg.load_toml(f)
+        assert reg.lookup("my_plugin") is not None
+
+    def test_load_toml_divergent_name_rejected(self, tmp_path: Path) -> None:
+        # Regression for v0.1.0 release hardening: a TOML table with
+        # ``[my_plugin]`` whose body declares ``name = "different"`` used
+        # to register under ``"different"``, leaving ``lookup("my_plugin")``
+        # as a confusing miss. Now rejected at load with a clear error.
+        f = tmp_path / "sigs.toml"
+        f.write_text(
+            '[my_plugin]\nname = "different_name"\nsemantic_class = "extractor"\n'
+            'source_keys = ["src"]\ndest_keys = ["dst"]\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        with pytest.raises(ValueError) as excinfo:
+            reg.load_toml(f)
+        msg = str(excinfo.value)
+        assert "[my_plugin]" in msg
+        assert "different_name" in msg
+
+    def test_load_toml_oversize_file_rejected(self, tmp_path: Path) -> None:
+        # 1 MiB cap protects against accidentally pointing the loader at
+        # a huge file. Build something just over the cap.
+        f = tmp_path / "huge.toml"
+        # Pad with a comment block; TOML parser doesn't care about
+        # comment content, but the byte cap fires before parsing starts.
+        comment = "# " + ("x" * 80) + "\n"
+        # Need > 1 MiB total; comment line is 83 bytes.
+        repeats = (1024 * 1024 // len(comment)) + 100
+        body = comment * repeats + '[ok]\nsemantic_class = "passthrough"\nsource_keys = []\ndest_keys = []\n'
+        f.write_text(body, encoding="utf-8")
+        # Sanity-check the test fixture itself is over the cap.
+        assert f.stat().st_size > 1024 * 1024
+        reg = PluginSignatureRegistry()
+        with pytest.raises(ValueError, match="exceeds"):
+            reg.load_toml(f)
+
+    def test_load_toml_at_size_cap_succeeds(self, tmp_path: Path) -> None:
+        # File at exactly the cap is allowed (the check is strict ``>``).
+        # Build something just under the cap.
+        f = tmp_path / "snug.toml"
+        prefix = '[snug]\nsemantic_class = "passthrough"\nsource_keys = []\ndest_keys = []\n'
+        # Pad with comments to ~ cap - 1 KB so we sit safely inside the limit.
+        target = (1024 * 1024) - 4096
+        pad = "# " + ("x" * 80) + "\n"
+        pad_count = (target - len(prefix)) // len(pad)
+        body = prefix + pad * max(0, pad_count)
+        f.write_text(body, encoding="utf-8")
+        assert f.stat().st_size < 1024 * 1024
+        reg = PluginSignatureRegistry()
+        reg.load_toml(f)
+        assert reg.lookup("snug") is not None
+
+    def test_load_directory_skips_outward_pointing_symlink(self, tmp_path: Path) -> None:
+        # Symlinks resolving outside the loaded directory are skipped: a
+        # configured signatures directory shouldn't unexpectedly pull
+        # TOML from elsewhere on the filesystem because someone dropped
+        # a symlink in. Symlinks pointing at files inside the same
+        # directory remain followed.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_toml = outside / "evil.toml"
+        outside_toml.write_text(
+            '[evil]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        loaded_dir = tmp_path / "loaded"
+        loaded_dir.mkdir()
+        # The symlink lives in loaded/, but its target is in outside/.
+        symlink = loaded_dir / "evil.toml"
+        try:
+            symlink.symlink_to(outside_toml)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+        # Also place a real TOML inside the loaded dir so we know the
+        # loader is working; the outward symlink must be skipped.
+        (loaded_dir / "real.toml").write_text(
+            '[real]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        reg = PluginSignatureRegistry()
+        reg.load_directory(loaded_dir)
+        assert "real" in reg
+        assert "evil" not in reg
+
+    def test_load_directory_follows_inward_symlink(self, tmp_path: Path) -> None:
+        # Sanity: a symlink that resolves to a sibling INSIDE the same
+        # directory is still followed. Otherwise the rule would reject
+        # legitimate intra-directory symlinks (e.g. ``current.toml -> v3.toml``).
+        loaded_dir = tmp_path / "loaded"
+        loaded_dir.mkdir()
+        target = loaded_dir / "v3.toml"
+        target.write_text(
+            '[v3]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        link = loaded_dir / "current.toml"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+        reg = PluginSignatureRegistry()
+        reg.load_directory(loaded_dir)
+        assert "v3" in reg
+
+    def test_load_directory_case_insensitive_filesystem_follows_in_dir_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On case-insensitive filesystems (macOS APFS, Windows NTFS),
+        ``Path.is_relative_to`` does case-sensitive string equality even
+        though the underlying lookup folds case. That mismatch would
+        false-reject a perfectly-valid in-dir symlink whenever the
+        configured directory happens to differ in case from the resolved
+        target — e.g. caller passes ``Loaded/`` but ``resolve()`` lowers
+        to ``loaded/``.
+
+        Simulate the case-insensitive filesystem on Linux runners by
+        monkeypatching ``os.path.normcase`` to ``str.casefold``. On macOS
+        ``normcase`` is already non-trivial and the test should pass
+        without the patch — we set it unconditionally to make CI behavior
+        portable. The fix in ``_path_is_within`` routes both sides
+        through ``normcase`` and accepts the case-mismatched directory as
+        equivalent.
+        """
+        import os
+
+        monkeypatch.setattr(os.path, "normcase", lambda p: p.casefold())
+        loaded_dir = tmp_path / "Loaded"
+        loaded_dir.mkdir()
+        target = loaded_dir / "v3.toml"
+        target.write_text(
+            '[v3]\nsemantic_class = "extractor"\nsource_keys = []\ndest_keys = []\n',
+            encoding="utf-8",
+        )
+        link = loaded_dir / "current.toml"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+
+        # Hand the loader a *case-mismatched* directory argument. Under
+        # the bare ``is_relative_to`` check this would (mistakenly)
+        # trip the outward-pointing test and skip the symlink; under
+        # ``_path_is_within`` it's followed.
+        case_mismatched = tmp_path / "loaded"
+        # Sanity: the literal-name path doesn't exist (only ``Loaded``
+        # does), so we explicitly hand the loader the real directory
+        # but probe the case-fold via the ``resolved_directory.resolve()``
+        # path. The simplest way to exercise that gap is to construct
+        # the expected vs. resolved cases directly through the helper.
+        from parser_lineage_analyzer._plugin_signatures import _path_is_within
+
+        # Resolved target lives under ``Loaded``; configured directory
+        # comes in lowercase. Without ``normcase``, ``is_relative_to``
+        # would return False; with it, ``_path_is_within`` returns True.
+        resolved_target = link.resolve()
+        assert _path_is_within(resolved_target, case_mismatched) is True
+        # And the inverse — a target genuinely outside (note: ``casefold``
+        # of two distinct names doesn't accidentally collapse them).
+        outside = tmp_path / "outside" / "evil.toml"
+        outside.parent.mkdir()
+        outside.write_text("body\n", encoding="utf-8")
+        assert _path_is_within(outside, case_mismatched) is False
+
     def test_from_paths_directories_then_files(self, tmp_path: Path) -> None:
         dir_ = tmp_path / "defaults"
         dir_.mkdir()

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -362,9 +362,9 @@ class TestTomlLoader:
         monkeypatching ``os.path.normcase`` to ``str.casefold``. On macOS
         ``normcase`` is already non-trivial and the test should pass
         without the patch — we set it unconditionally to make CI behavior
-        portable. The fix in ``_path_is_within`` routes both sides
-        through ``normcase`` and accepts the case-mismatched directory as
-        equivalent.
+        portable. The shared ``path_is_within`` helper (in
+        ``_path_safety``) routes both sides through ``normcase`` and
+        accepts the case-mismatched directory as equivalent.
         """
         import os
 
@@ -385,26 +385,26 @@ class TestTomlLoader:
         # Hand the loader a *case-mismatched* directory argument. Under
         # the bare ``is_relative_to`` check this would (mistakenly)
         # trip the outward-pointing test and skip the symlink; under
-        # ``_path_is_within`` it's followed.
+        # ``path_is_within`` it's followed.
         case_mismatched = tmp_path / "loaded"
         # Sanity: the literal-name path doesn't exist (only ``Loaded``
         # does), so we explicitly hand the loader the real directory
         # but probe the case-fold via the ``resolved_directory.resolve()``
         # path. The simplest way to exercise that gap is to construct
         # the expected vs. resolved cases directly through the helper.
-        from parser_lineage_analyzer._plugin_signatures import _path_is_within
+        from parser_lineage_analyzer._path_safety import path_is_within
 
         # Resolved target lives under ``Loaded``; configured directory
         # comes in lowercase. Without ``normcase``, ``is_relative_to``
-        # would return False; with it, ``_path_is_within`` returns True.
+        # would return False; with it, ``path_is_within`` returns True.
         resolved_target = link.resolve()
-        assert _path_is_within(resolved_target, case_mismatched) is True
+        assert path_is_within(resolved_target, case_mismatched) is True
         # And the inverse — a target genuinely outside (note: ``casefold``
         # of two distinct names doesn't accidentally collapse them).
         outside = tmp_path / "outside" / "evil.toml"
         outside.parent.mkdir()
         outside.write_text("body\n", encoding="utf-8")
-        assert _path_is_within(outside, case_mismatched) is False
+        assert path_is_within(outside, case_mismatched) is False
 
     def test_from_paths_directories_then_files(self, tmp_path: Path) -> None:
         dir_ = tmp_path / "defaults"

--- a/tests/test_regex_algebra.py
+++ b/tests/test_regex_algebra.py
@@ -56,6 +56,28 @@ from parser_lineage_analyzer._regex_algebra import (
 )
 
 
+@pytest.fixture
+def _clear_definitive_caches() -> Iterator[None]:
+    """Clear the three module-level LRU caches before *and* after the
+    test, so a stray entry from an earlier run can't perturb a
+    timing-sensitive cache assertion (sizes, eviction order, miss
+    behavior). Tests that exercise the definitive caches opt in via
+    ``@pytest.mark.usefixtures("_clear_definitive_caches")``.
+
+    The canonical clear API is ``cache.clear()`` on each
+    ``OrderedDict`` — there is no module-level ``clear_caches`` helper.
+    """
+    from parser_lineage_analyzer import _regex_algebra as algebra
+
+    algebra._DEFINITIVE_DISJOINT_CACHE.clear()
+    algebra._DEFINITIVE_SUBSET_CACHE.clear()
+    algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE.clear()
+    yield
+    algebra._DEFINITIVE_DISJOINT_CACHE.clear()
+    algebra._DEFINITIVE_SUBSET_CACHE.clear()
+    algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE.clear()
+
+
 class TestExtractRegexLiteral:
     @pytest.mark.parametrize(
         "condition,field,body,flags",
@@ -90,6 +112,19 @@ class TestExtractRegexLiteral:
         body = "a" * (MAX_REGEX_BODY_BYTES + 1)
         condition = f"[t] =~ /{body}/"
         assert extract_regex_literal(condition) is None
+
+    def test_rejects_empty_body(self) -> None:
+        # Regression for v0.1.0 release hardening: an empty body
+        # (``[t] =~ //``) matches the empty string under Python ``re`` so
+        # carries no shape constraint. Returning a ``RegexLiteral`` for
+        # it would only bloat algebra cache keys with degenerate entries.
+        assert extract_regex_literal("[t] =~ //") is None
+        assert extract_regex_literal("[t] !~ //") is None
+        # A body containing just a flag character (so ``body`` matches
+        # but is empty) sanity-check; the regex requires at least the
+        # body group to capture, but the trailing flag-letters group is
+        # separate. Just confirm a plausible empty form rejects.
+        assert extract_regex_literal("[t] =~ //i") is None
 
 
 class TestExactLiteralRecognition:
@@ -383,6 +418,34 @@ class TestLanguageSubset:
         # Σ* contains any anchored literal.
         assert language_subset("^foo$", "", ".*", "") == Trilean.YES
 
+    def test_intersect_empty_dfa_partition_mismatch_returns_unknown(self) -> None:
+        # Regression for v0.1.0 release hardening: ``_intersect_empty_dfa``
+        # used to ``raise ValueError`` on a partition mismatch. The file's
+        # stated soundness contract is "never raise; degrade to UNKNOWN" —
+        # the raise propagated up and crashed the analyzer instead of
+        # falling back to compatible-as-default.
+        #
+        # The public callers (``language_subset``) construct both DFAs
+        # over the same partition by design, so this code path is not
+        # reachable from public APIs in the current implementation. The
+        # white-box test invokes ``_intersect_empty_dfa`` directly with
+        # mismatched partitions to pin the never-raise contract.
+        from parser_lineage_analyzer._regex_algebra import (
+            _DFA,
+            _Budget,
+            _CharSet,
+            _intersect_empty_dfa,
+        )
+
+        # Two minimal DFAs over different alphabets. Concrete shape doesn't
+        # matter for this test; only the partition-equality check fires.
+        cs_a = _CharSet(frozenset({ord("a")}), False)
+        cs_b = _CharSet(frozenset({ord("b")}), False)
+        dfa_a = _DFA(num_states=1, start=0, accepts=frozenset({0}), transitions={}, partition=(cs_a,))
+        dfa_b = _DFA(num_states=1, start=0, accepts=frozenset({0}), transitions={}, partition=(cs_b,))
+        result = _intersect_empty_dfa(dfa_a, dfa_b, _Budget.fresh())
+        assert result == Trilean.UNKNOWN
+
 
 class TestLiteralInRegexLanguage:
     """``literal_in_regex_language(literal, body, flags)`` returns YES
@@ -413,6 +476,71 @@ class TestLiteralInRegexLanguage:
     def test_oversized_literal_is_unknown(self) -> None:
         big = "x" * (MAX_REGEX_BODY_BYTES + 1)
         assert literal_in_regex_language(big, "^x+$", "") == Trilean.UNKNOWN
+
+    @pytest.mark.usefixtures("_clear_definitive_caches")
+    def test_definitive_cache_caches_yes_no(self) -> None:
+        # Regression for v0.1.0 release hardening: ``literal_in_regex_language``
+        # now has its own definitive-only cache mirroring the disjoint /
+        # subset caches. YES and NO answers stick; UNKNOWN does not.
+        from parser_lineage_analyzer import _regex_algebra as algebra
+
+        # Unique key not used elsewhere in the suite.
+        literal = "uncached_membership_lit"
+        body = "^uncached_membership_lit$"
+        key: tuple[str, ...] = (literal, body, "")
+
+        # Cold call — populates the cache.
+        result = literal_in_regex_language(literal, body, "")
+        assert result == Trilean.YES
+        assert algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE.get(key) == Trilean.YES
+
+        # NO answer also caches.
+        body_no = "^totally_different$"
+        key_no: tuple[str, ...] = (literal, body_no, "")
+        result_no = literal_in_regex_language(literal, body_no, "")
+        assert result_no == Trilean.NO
+        assert algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE.get(key_no) == Trilean.NO
+
+    @pytest.mark.usefixtures("_clear_definitive_caches")
+    def test_definitive_cache_skips_unknown(self) -> None:
+        # UNKNOWN must NOT be memoized: a transient cap hit shouldn't
+        # mask a definitive YES/NO that a fresh budget could prove.
+        from parser_lineage_analyzer import _regex_algebra as algebra
+
+        literal = "uncached_membership_unknown_lit"
+        body = "^uncached_membership_unknown$"
+        key: tuple[str, ...] = (literal, body, "")
+
+        # Force an UNKNOWN by patching the inner BFS to bail.
+        original = algebra._intersect_empty_nfa
+        algebra._intersect_empty_nfa = lambda *_args, **_kwargs: Trilean.UNKNOWN
+        try:
+            literal_in_regex_language(literal, body, "")
+        finally:
+            algebra._intersect_empty_nfa = original
+        # The load-bearing assertion is the cache-miss: an UNKNOWN result
+        # MUST NOT have been memoized (asserting that
+        # ``literal_in_regex_language`` returned UNKNOWN under the patched
+        # lambda would only be testing the patch itself).
+        assert key not in algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE
+
+        # A subsequent call with the real algebra computes a definitive
+        # answer (NO — the literal doesn't match the body) and caches it.
+        result_real = literal_in_regex_language(literal, body, "")
+        assert result_real == Trilean.NO
+        assert algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE.get(key) == Trilean.NO
+
+    @pytest.mark.usefixtures("_clear_definitive_caches")
+    def test_definitive_cache_respects_max_size(self) -> None:
+        # LRU eviction kicks in once the cap is reached. Stuff more than
+        # ``_DEFINITIVE_CACHE_MAX`` distinct keys through and verify the
+        # cache size never exceeds it.
+        from parser_lineage_analyzer import _regex_algebra as algebra
+
+        # Use small fast pairs to keep the test cheap. cap + 64 distinct keys.
+        for i in range(algebra._DEFINITIVE_CACHE_MAX + 64):
+            literal_in_regex_language(f"lit{i}", f"^lit{i}$", "")
+        assert len(algebra._DEFINITIVE_LITERAL_MEMBERSHIP_CACHE) <= algebra._DEFINITIVE_CACHE_MAX
 
 
 class TestSoundnessCrossCheck:
@@ -706,7 +834,7 @@ class TestNegMatchExtraction:
         # matches before a final ``\n``, so ``!~ /^foo$/`` excludes both
         # ``"foo"`` and ``"foo\n"`` while ``[t] != "foo"`` only excludes
         # ``"foo"``. Letting the negative-match literal collapse would
-        # invert under ``negated_literal_fact_from_condition`` into the
+        # invert under the ``NOT`` reduction into the
         # narrower ``[t] == "foo"`` claim and unsoundly contradict peers
         # whose witnesses lie in ``L(=~ /^foo$/) \ {"foo"}`` (e.g.
         # ``"foo\n"``). Keep it as a RegexFact so the symbolic algebra
@@ -808,7 +936,7 @@ class TestNegMatchExtraction:
         # Regression for chatgpt-codex-connector finding on PR #8.
         #
         # If ``!~ /^foo$/`` were collapsed to ``LiteralFact("foo", neq)``
-        # and then negated via ``negated_literal_fact_from_condition``,
+        # and then negated via the ``NOT`` literal-fact reduction,
         # the result would be ``LiteralFact("foo", eq)``. Paired with
         # ``[t] != "foo"`` that produces a same-field, same-value, opposite-
         # ``is_equal`` pair which the LiteralFact dispatch contradicts.
@@ -1063,6 +1191,7 @@ class TestReviewFindings:
         assert literal_in_regex_language("alert_FOO_msg", "(?i:foo)", "") == Trilean.YES
         assert literal_in_regex_language("alert_BAR_msg", "(?i:foo)", "") == Trilean.NO
 
+    @pytest.mark.usefixtures("_clear_definitive_caches")
     def test_unknown_results_are_not_cached(self) -> None:
         """A transient cap hit (cold caches under load, slow CI, etc.)
         can make ``regex_languages_disjoint`` return ``UNKNOWN`` for
@@ -1082,9 +1211,6 @@ class TestReviewFindings:
         # definitive cache for these bodies.
         body_a = "^uncached_test_disjoint_a$"
         body_b = "^uncached_test_disjoint_b$"
-
-        # Clear caches up front so the test is independent.
-        algebra._DEFINITIVE_DISJOINT_CACHE.clear()
 
         # Force an UNKNOWN by patching the BFS to bail. We do this by
         # temporarily replacing ``_intersect_empty_nfa`` with a stub.
@@ -1160,6 +1286,7 @@ class TestReviewFindings:
         # move when the cap fires before the proof lands).
         assert result in (Trilean.YES, Trilean.UNKNOWN), result
 
+    @pytest.mark.usefixtures("_clear_definitive_caches")
     def test_definitive_caches_are_concurrent_safe(self) -> None:
         """Hammer the definitive caches from multiple threads while
         evicting under the cap. The lock around get/put plus the
@@ -1170,8 +1297,6 @@ class TestReviewFindings:
         import threading
 
         from parser_lineage_analyzer import _regex_algebra as algebra
-
-        algebra._DEFINITIVE_DISJOINT_CACHE.clear()
 
         # Generate enough distinct (small, fast) regex pairs to force
         # repeated evictions: cap + 64 distinct keys, hit by 8 threads.

--- a/tests/test_regex_algebra_properties.py
+++ b/tests/test_regex_algebra_properties.py
@@ -46,16 +46,22 @@ from parser_lineage_analyzer._regex_algebra import (
 
 # The production budget (``ALGEBRA_TIME_BUDGET_MS = 25``) is sized for
 # the analyzer's hot path: many algebra calls per branch, all required
-# to settle within a parser run. Property tests run hundreds of varied
-# inputs in succession and want to verify the algebra's *correctness*,
-# not its bail-out behavior — under runner contention (CI GC pauses,
-# scheduler delays) a 25 ms wall-clock budget can fire on inputs that
-# locally complete in <1 ms, producing asymmetric ``UNKNOWN`` results
-# that break properties like ``test_disjoint_is_symmetric``.
+# to settle within a parser run. A subset of property tests run two
+# algebra calls and require their results to agree (e.g. symmetry of
+# ``regex_languages_disjoint`` calls under both argument orders, or a
+# ground-truth cross-check that depends on a definite YES/NO from the
+# algebra). Under runner contention (CI GC pauses, scheduler delays) a
+# 25 ms wall-clock budget can fire on inputs that locally complete in
+# <1 ms, producing asymmetric ``UNKNOWN`` results that broke
+# ``test_disjoint_is_symmetric`` historically.
 #
-# A 1 s budget per call is still bounded (so a genuine pathological
-# input still bails out) but eliminates the budget-noise flake.
-@pytest.fixture(autouse=True)
+# Rather than inflating the budget for *every* property test in this
+# file (which would mask any real budget regression detected by the
+# simpler tests below), expose this as an opt-in fixture and apply it
+# only to tests that actually pair multiple algebra calls. A 1 s budget
+# per call is still bounded (so a genuine pathological input still bails
+# out) but eliminates the budget-noise flake.
+@pytest.fixture
 def _generous_algebra_budget(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_regex_algebra, "ALGEBRA_TIME_BUDGET_MS", 1000)
 
@@ -159,15 +165,23 @@ def test_subset_is_reflexive(body: str) -> None:
     assert result in (Trilean.YES, Trilean.UNKNOWN)
 
 
+@pytest.mark.usefixtures("_generous_algebra_budget")
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_disjoint_is_symmetric(a: str, b: str) -> None:
+    # Symmetry pairs two algebra calls and requires them to agree. This
+    # is the original budget-flake offender (see fixture comment above).
     assert regex_languages_disjoint(a, "", b, "") == regex_languages_disjoint(b, "", a, "")
 
 
+@pytest.mark.usefixtures("_generous_algebra_budget")
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_disjoint_yes_means_no_string_matches_both(a: str, b: str) -> None:
+    # Cross-checks an algebra YES against brute-force enumeration: a
+    # budget-bail UNKNOWN here is fine in isolation but interacts with
+    # the YES->ground-truth contract enough that we hold the budget
+    # stable for clean results across CI variance.
     result = regex_languages_disjoint(a, "", b, "")
     assume(result == Trilean.YES)
     for s in _ALL_STRINGS:
@@ -176,6 +190,7 @@ def test_disjoint_yes_means_no_string_matches_both(a: str, b: str) -> None:
         assert not (a_match and b_match), f"algebra said {a!r} and {b!r} disjoint, but {s!r} matches both"
 
 
+@pytest.mark.usefixtures("_generous_algebra_budget")
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_disjoint_no_means_some_string_matches_both(a: str, b: str) -> None:
@@ -213,9 +228,12 @@ def test_literal_in_language_no_agrees_with_re(body: str, s: str) -> None:
     assert not _matches_via_re(body, s), f"algebra said {s!r} doesn't match {body!r}, but re finds a match"
 
 
+@pytest.mark.usefixtures("_generous_algebra_budget")
 @given(_maybe_alternation(), _maybe_alternation())
 @_HYP_SETTINGS
 def test_subset_yes_implies_no_witness_in_a_minus_b(a: str, b: str) -> None:
+    # Cross-checks an algebra YES against brute-force enumeration; same
+    # reasoning as the disjoint cross-checks above.
     result = language_subset(a, "", b, "")
     assume(result == Trilean.YES)
     for s in _ALL_STRINGS:
@@ -272,11 +290,15 @@ def _condition_satisfied(body: str, is_match: bool, value: str) -> bool:
     return matched if is_match else not matched
 
 
+@pytest.mark.usefixtures("_generous_algebra_budget")
 @given(_maybe_alternation(), _maybe_alternation(), st.booleans(), st.booleans())
 @_HYP_SETTINGS
 def test_compatible_false_means_no_witness(body_a: str, body_b: str, op_a_is_match: bool, op_b_is_match: bool) -> None:
     """If the algebra calls a pair contradicted, no enumerated value
     satisfies both halves. This is the load-bearing soundness check."""
+    # ``conditions_are_compatible`` runs multiple algebra calls under the
+    # hood, so we hold the budget steady to avoid budget-bail noise
+    # leaking into the contradiction oracle.
     op_a = "=~" if op_a_is_match else "!~"
     op_b = "=~" if op_b_is_match else "!~"
     cond_a = f"[t] {op_a} /{body_a}/"


### PR DESCRIPTION
## Summary

Three-cycle parallel-agent review of the v0.1.0 release surface across performance, correctness, maintenance, UX, code review, and security. 29 files changed (+1546/−171); 33 new tests (1585 → 1618).

## What changed

### Correctness / soundness
- **Re-grok now invalidates the prior implicit grok constraint on every call**, regardless of body size or trivial-body or library-miss. Previously the 513–8192-byte gap silently kept stale constraints (an unsound carry-over from PR #13).
- `_intersect_empty_dfa` returns `Trilean.UNKNOWN` on partition mismatch instead of raising, honouring the file-level "never raise; degrade to UNKNOWN" contract.
- `extract_regex_literal` rejects empty bodies up front.
- Deleted the dead public `negated_literal_fact_from_condition`; the unsound `!~ /^literal$/` reduction it would expose is no longer importable.

### Security hardening
- **Plugin-signature TOML loader**: 1 MiB cap before `tomllib.load`; `TOMLDecodeError` wrapped to `ValueError` with path context (no traceback leaks); divergent `[table]` key vs explicit `name=` rejected; outward-pointing symlinks in `--plugin-signatures-dir` skipped.
- **Grok pattern loader**: 1 MiB per-file size cap; outward-pointing symlinks in `--grok-patterns-dir` skipped.
- Symlink-containment check uses `os.path.normcase` to close the gap on Windows; POSIX behaviour unchanged. Fail-safe: rejects mismatches rather than accepting.
- Bounded the `_QUOTED_OVER_ESCAPE` warning-rendering regex to `{0,1024}` per side to defuse adversarial backtracking.

### UX / CLI
- **Lazy CLI imports**: `--help` and `--version` no longer load `analyzer`, `pydantic`, or `render` (~138 ms → ~25 ms cold start).
- **JSON schema stability**: plain `--json` always emits `unsupported`, `warnings`, `output_anchors`, `structured_warnings`, `diagnostics` as `[]` when empty; `--list --json` and `--summary --json` mirror the same top-level shape.
- New `--include-pattern-bodies` flag opts the resolved grok regex body into JSON `details` (suppressed by default to keep `jq | head` legible).
- `--strict --json` embeds a `strict_failure` key alongside the preserved stderr summary.
- `--strict` help text disambiguates parser-level warnings from query-level uncertainty.
- `--compact-summary` always prints the `Taint counts by code:` heading.
- Warning text re-renders single-quoted regex bodies with single backslashes that match user source verbatim.
- README: flag table now covers `--grok-patterns-dir`, `--plugin-signatures`, `--plugin-signatures-dir`, `--include-pattern-bodies`, `--version`; new Limitations bullet for ASCII-only regex algebra; quickstart matches actual output.

### Performance
- New `_DEFINITIVE_LITERAL_MEMBERSHIP_CACHE` for literal-vs-regex contradiction checks (mirrors the existing disjoint/subset caches).

### Maintenance / packaging
- Wheel and sdist no longer ship `__pycache__/*.pyc`.
- `lark>=1.3.1,<2` aligned across `pyproject.toml`, `README`, and CI (CI was on `lark>=1.1`).
- `concurrency: cancel-in-progress` added to `wheels.yml` and `codeql.yml` (PR-only; main/tag pushes queue safely).
- `twine check` + `attestations: true` added before the PyPI publish action.
- Dependabot grouped via `applies-to: version-updates` so security advisories ship as standalone PRs.
- `PERF_SLOW_FACTOR` env knob lets CI runners scale perf-test budgets.
- Property-test budget fixture is now per-test (was autouse-wide at 40× — masked real regressions).
- Stale per-file `mypy: disable-error-code="explicit-any"` directive replaced with per-class `# type: ignore[explicit-any]`.
- `_analysis_executor` collision message includes module names.

## Why

We're tagging v0.1.0 next. This pass surfaces and remediates the gaps that would otherwise turn into post-release noise: a soundness hole in re-grok (#13 follow-on), CLI cold-start that drowned single-shot invocations, JSON schemas that varied by mode, plugin-signature/grok loaders that lacked size and symlink hardening, and packaging that shipped `.pyc` files into the wheel.

## Reviewer notes

- **Three deferred items**, documented inline:
  - `_analysis_flow.py:546-565` — `no_op_state.clone()` optimization deferred (would alias `_apply_dropped_path_conditions` and `merge_branch_records`); ~7% of analyze-time on if-without-else workloads.
  - Native branch-merge extension shows no measurable benefit on the canonical `independent_if` benchmark — re-profile on a workload with more lineages per branch before deciding.
  - `--include-pattern-bodies` is JSON-only today; threading through `render_text` is a v0.1.1 follow-up.
- The `_path_is_within` helper is duplicated in `_plugin_signatures.py` and `_grok_patterns.py` — no shared private-utility module exists; comment in each file states they must not drift.
- README's `*_total` parenthetical was tightened to reflect that compact-mode counters are unconditional (not gated on sampling).
- `--list --json` now emits `output_anchors: []` for cross-mode shape parity (was missing in the first pass; caught by the Cycle 3 recheck-gate).

## Test plan

- [x] Full suite: `python -m pytest tests/` → 1618 passed (was 1585).
- [x] Lint: `ruff format --check && ruff check`.
- [x] Type: `mypy parser_lineage_analyzer`.
- [x] SAST: `bandit -c pyproject.toml -r parser_lineage_analyzer scripts -ll`.
- [x] Dependency vulns: `pip-audit -r reqs.txt --strict`.
- [x] Build: `python -m build --sdist --wheel`; wheel + sdist contain zero `*.pyc`/`__pycache__` entries.
- [x] Distribution metadata: `twine check dist/*` PASSED both artifacts.
- [x] CLI smoke: `--help`, `--version`, query-mode, `--json`, `--json --strict`, `--list --json`, `--summary --json`, `--compact-summary`, `--include-pattern-bodies` — all behave as documented.
- [x] CLI cold start: `time python -m parser_lineage_analyzer --help` ≈ 25 ms (was 138 ms).
- [x] Adversarial inputs: 1.5 MiB plugin TOML rejected; malformed TOML wrapped to `ValueError` (no traceback); outward-pointing symlinks skipped; case-mismatched directory args fail-safe; `_QUOTED_OVER_ESCAPE` < 50 ms on 1024-char no-close-quote input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--include-pattern-bodies` flag to export resolved grok regex bodies in JSON output
  * Added `--plugin-signatures-dir` for loading plugin signatures from TOML files or directories
  * Added `--version` CLI flag

* **Bug Fixes**
  * Fixed backslash escaping in warning text output
  * JSON output now includes stable top-level key schema
  * Added 1 MiB file size caps for plugin and grok pattern loading
  * Symlink directory traversal is now prevented during loading
  * Plugin signature validation enforces matching `name` field in TOML

* **Documentation**
  * Updated README with new CLI options and JSON output format specifications
  * Updated CHANGELOG with new features and behavioral changes
  * Clarified `--strict` exit code 3 semantics for parser warnings

* **Tests**
  * Added comprehensive coverage for file size limits and symlink handling
  * Added JSON schema stability tests
  * Added `PERF_SLOW_FACTOR` support for tunable CI performance budgets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->