### PR TITLE
Fix regex literal contradiction handling for newline-ambiguous anchors

### DIFF
--- a/parser_lineage_analyzer/_analysis_condition_facts.py
+++ b/parser_lineage_analyzer/_analysis_condition_facts.py
@@ -86,7 +86,8 @@ def _decode_condition_string(value: str) -> str:
     i = 0
     while i < len(value):
         if value[i] == "\\" and i + 1 < len(value):
-            out.append(value[i + 1])
+            escaped = value[i + 1]
+            out.append({"n": "\n", "r": "\r", "t": "\t"}.get(escaped, escaped))
             i += 2
             continue
         out.append(value[i])
@@ -106,25 +107,26 @@ def _literal_fact_from_normalized_condition(condition: str) -> LiteralFact | Non
     m = _NE_RE.match(condition)
     if m:
         return LiteralFact(m.group("field"), _decode_condition_string(m.group("value")), False)
-    regex_literal = _regex_exact_literal_value(condition)
+    regex_literal = _safe_regex_literal_fact_from_normalized_condition(condition)
     if regex_literal is not None:
-        field, value = regex_literal
-        return LiteralFact(field, value)
-    # Intentional gap: ``[t] !~ /^literal$/`` is NOT reduced to
-    # ``LiteralFact(literal, is_equal=False)`` here, even though the body
-    # matches the EXACT_LITERAL shape. Reason: the analyzer's reality
-    # model uses Python ``re.search`` semantics, where ``$`` matches
-    # before a final ``\n``. So ``!~ /^foo$/`` excludes both ``"foo"``
-    # *and* ``"foo\n"``, while ``LiteralFact("foo", neq)`` would only
-    # exclude ``"foo"``. Sound on its own, but the negated-literal
-    # reduction would flip the LiteralFact's ``is_equal`` and produce
-    # the false claim that ``NOT(!~ /^foo$/)`` means ``[t] == "foo"``
-    # — a *narrower* match-set than the true ``=~ /^foo$/`` semantics.
-    # That narrower set unsoundly contradicts a peer fact like
-    # ``[t] != "foo"`` whose witness ``"foo\n"`` lies *outside* the
-    # narrowed set but *inside* the true regex language. Letting ``!~``
-    # stay as a :class:`RegexFact` keeps the algebra reasoning faithful.
+        return regex_literal
+    # Intentional gap: ``[t] =~ /^literal$/`` and ``[t] !~ /^literal$/`` are
+    # not reduced to value-equality facts when the regex language also admits
+    # ``"literal\n"`` via Python/Ruby ``$`` semantics. The literal classifier
+    # still recognizes these bodies for diagnostics, but contradiction facts
+    # keep them as RegexFacts so Phase 1 can reason about the wider language.
     return None
+
+
+def _safe_regex_literal_fact_from_normalized_condition(condition: str) -> LiteralFact | None:
+    regex_literal = _regex_exact_literal_value(condition)
+    extracted = extract_regex_literal(condition)
+    if regex_literal is None or extracted is None:
+        return None
+    field, value = regex_literal
+    if literal_in_regex_language(f"{value}\n", extracted.body, extracted.flags) != Trilean.NO:
+        return None
+    return LiteralFact(field, value)
 
 
 def _regex_fact_from_normalized_condition(condition: str) -> RegexFact | None:
@@ -140,6 +142,16 @@ def _regex_fact_from_normalized_condition(condition: str) -> RegexFact | None:
     return RegexFact(extracted.field, extracted.body, extracted.flags, is_match=extracted.is_match)
 
 
+def _negated_regex_fact_from_normalized_condition(condition: str) -> RegexFact | None:
+    m = _NEGATED_RE.match(condition)
+    if not m:
+        return None
+    fact = _regex_fact_from_normalized_condition(_normalize_condition(m.group("inner")))
+    if fact is None:
+        return None
+    return RegexFact(fact.field, fact.body, fact.flags, is_match=not fact.is_match)
+
+
 @lru_cache(maxsize=8192)
 def _fact_from_condition(condition: str) -> Fact | None:
     condition = _normalize_condition(condition)
@@ -148,6 +160,9 @@ def _fact_from_condition(condition: str) -> Fact | None:
     )
     if literal is not None:
         return literal
+    negated_regex = _negated_regex_fact_from_normalized_condition(condition)
+    if negated_regex is not None:
+        return negated_regex
     # Phase 1: a ``=~``/``!~`` whose body wasn't reducible to a LiteralFact
     # becomes a RegexFact for the symbolic algebra to reason about.
     return _regex_fact_from_normalized_condition(condition)

--- a/tests/test_adversarial_exploits.py
+++ b/tests/test_adversarial_exploits.py
@@ -147,22 +147,25 @@ class TestOnErrorDepth:
 
 
 class TestConditionContradictionGaps:
-    def test_exact_regex_equivalent_else_if_branch_is_skipped(self):
+    def test_dollar_anchored_regex_else_if_branch_remains_reachable(self):
         code = r"""
         filter {
           json { source => "message" }
           if [type] == "A" {
             mutate { replace => { "event.idm.read_only_udm.metadata.event_type" => "PROCESS_LAUNCH" } }
           } else if [type] =~ /^A$/ {
-            mutate { replace => { "event.idm.read_only_udm.metadata.event_type" => "SHOULD_BE_UNREACHABLE" } }
+            mutate { replace => { "event.idm.read_only_udm.metadata.event_type" => "REACHABLE_WITH_TRAILING_NEWLINE" } }
           }
         }
         """
 
         result = ReverseParser(code).query("metadata.event_type")
 
-        assert [mapping.expression for mapping in result.mappings] == ["PROCESS_LAUNCH"]
-        assert any("contradicts" in warning for warning in result.warnings)
+        assert [mapping.expression for mapping in result.mappings] == [
+            "PROCESS_LAUNCH",
+            "REACHABLE_WITH_TRAILING_NEWLINE",
+        ]
+        assert not any("contradicts" in warning for warning in result.warnings)
 
     def test_inequality_branch_fact_makes_else_if_unreachable(self):
         code = r"""

--- a/tests/test_regex_algebra.py
+++ b/tests/test_regex_algebra.py
@@ -154,7 +154,6 @@ class TestExactLiteralRecognition:
     def test_recognizes_anchored_literal(self, condition: str, field: str, literal: str) -> None:
         assert exact_literal_value(condition) == (field, literal)
         assert is_exact_literal_regex_condition(condition)
-        assert _literal_fact_from_normalized_condition(condition) == LiteralFact(field, literal)
 
 
 class TestSoundnessGuards:
@@ -719,11 +718,15 @@ class TestRegexFactWiring:
         assert fact.body == "^[A-Z]+$"
         assert fact.is_match is True
 
-    def test_literal_fact_still_preferred_for_pure_literal_body(self) -> None:
-        # ``=~ /^foo$/`` reduces to a LiteralFact (Phase 0 behavior).
+    def test_newline_ambiguous_literal_body_uses_regex_fact(self) -> None:
+        # ``=~ /^foo$/`` remains an exact-literal shape for diagnostics, but
+        # contradiction facts keep the RegexFact so ``"foo\n"`` stays in the
+        # language under ``$`` anchor semantics.
         fact = _fact_from_condition("[t] =~ /^foo$/")
-        assert isinstance(fact, LiteralFact)
-        assert fact.value == "foo"
+        assert isinstance(fact, RegexFact)
+        assert fact.field == "[t]"
+        assert fact.body == "^foo$"
+        assert fact.is_match is True
 
     @pytest.mark.parametrize(
         "conditions,compatible",
@@ -845,6 +848,18 @@ class TestNegMatchExtraction:
         assert fact.body == "^foo$"
         assert fact.is_match is False
 
+    def test_pos_match_literal_body_stays_regex_fact_when_dollar_newline_ambiguous(self) -> None:
+        # ``exact_literal_value`` still recognizes the public Phase 0 shape,
+        # but the contradiction engine must not narrow ``^foo$`` to
+        # LiteralFact("foo") because the regex also matches ``"foo\n"``.
+        assert exact_literal_value("[t] =~ /^foo$/") == ("[t]", "foo")
+        assert _literal_fact_from_normalized_condition("[t] =~ /^foo$/") is None
+        fact = _fact_from_condition("[t] =~ /^foo$/")
+        assert isinstance(fact, RegexFact)
+        assert fact.field == "[t]"
+        assert fact.body == "^foo$"
+        assert fact.is_match is True
+
     def test_neg_match_non_literal_body_emits_regex_fact(self) -> None:
         fact = _fact_from_condition("[t] !~ /^[A-Z]+$/")
         assert isinstance(fact, RegexFact)
@@ -902,6 +917,11 @@ class TestNegMatchExtraction:
             # consults `literal_in_regex_language` and finds the contradiction.
             (['[t] == "foo"', "[t] !~ /^foo$/"], False),
             (['[t] != "foo"', "[t] !~ /^foo$/"], True),
+            # Positive literal-looking regexes stay as RegexFact so the
+            # trailing-newline witness is preserved.
+            (['[t] == "foo\\n"', "[t] =~ /^foo$/"], True),
+            (['[t] == "foo"', "[t] =~ /^foo$/"], True),
+            (['[t] == "bar"', "[t] =~ /^foo$/"], False),
             # Same field positive vs negative on identical body — algebra
             # detects via `language_subset(body, body) == YES`.
             (["[t] =~ /^[A-Z]+$/", "[t] !~ /^[A-Z]+$/"], False),
@@ -950,6 +970,7 @@ class TestNegMatchExtraction:
         assert conditions_are_compatible(["NOT([t] !~ /^foo$/)", '[t] != "foo"']) is True
         # And the symmetric existing-behavior check (already sound):
         assert conditions_are_compatible(["NOT([t] =~ /^foo$/)", '[t] == "foo"']) is False
+        assert conditions_are_compatible(["NOT([t] =~ /^foo$/)", '[t] == "foo\\n"']) is False
 
 
 class TestRegexStressFile:


### PR DESCRIPTION
## Summary
- Preserve `=~ /^literal$/` as a regex fact when `$` can also match before a trailing newline, so contradiction reasoning stays sound.
- Keep `exact_literal_value()` and regex-shape diagnostics unchanged, but stop promoting ambiguous exact literals into `LiteralFact`.
- Add regression coverage for `foo\n` compatibility, negation round-trips, and the reachable else-if branch case.

## Testing
- `python -m pytest tests/test_regex_algebra.py -q`
- `python -m pytest -q`
- `python -m pytest tests/test_regex_algebra_properties.py -q --hypothesis-profile=deep`
- `ruff format --check parser_lineage_analyzer scripts tests fuzz setup.py`
- `ruff check parser_lineage_analyzer scripts tests fuzz setup.py`
- `mypy parser_lineage_analyzer`