### PR TITLE
[codex] improve Logstash and SecOps parser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- In SecOps dialect mode, Logstash-only external lookup plugins such as
+  `elasticsearch`, `memcached`, `jdbc_streaming`, `http`, `rest`, and
+  `acme_threat_lookup` now report `plugin_dialect_disabled` and do not write
+  conservative target lineage. Use `dialect="logstash"` / `--dialect logstash`
+  when analyzing Logstash pipelines that rely on those plugins.
+
 ## [0.1.0] - 2026-04-26
 
 Initial public release.
@@ -75,4 +84,5 @@ Initial public release.
   ({0,1024} per side) so adversarial parser source can't trigger
   catastrophic backtracking.
 
+[Unreleased]: https://github.com/JudgeZ/parser-lineage-analyzer/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/JudgeZ/parser-lineage-analyzer/releases/tag/v0.1.0

--- a/docs/plugin-signatures.md
+++ b/docs/plugin-signatures.md
@@ -207,13 +207,13 @@ Two safety nets:
 
 ## Bundled signatures
 
-v0.2 ships **no bundled signatures**. The `parser_lineage_analyzer/
-plugin_signatures/` directory is intentionally empty; the loader
-consults it so future bundled additions need no code change.
+The package ships a small audited bundle under
+`parser_lineage_analyzer/plugin_signatures/`. These signatures are
+conservative and are not loaded unless a caller explicitly uses
+`load_bundled_registry()` or passes them through the existing
+signature-loading path.
 
-The deliberate choice is to avoid silently shipping signatures that
-a user might rely on without auditing — a wrong signature for a
-real plugin can produce misleading lineage, which is worse than no
-lineage. Examples in this document are pedagogical only; copy what
-fits your environment, audit it, and load it via your own
-`--plugin-signatures` files.
+Bundled signatures are intentionally approximate: they reduce hard
+`unsupported_plugin` output for common opaque enrichers, while dynamic
+or external behavior remains tainted. For organization-specific plugins,
+prefer loading your own audited `--plugin-signatures` files.

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Iterable
 from functools import lru_cache
@@ -38,7 +39,8 @@ from ._analysis_helpers import (
     _taint_key,
     _warning_key,
 )
-from ._analysis_state import AnalyzerState, BranchRecord
+from ._analysis_state import AnalyzerState, BranchRecord, FailureTagRoute
+from ._plugin_specs import PLUGIN_SPECS, PluginSpec, dialect_profile_for, plugin_spec_for
 from ._types import ConfigPair, ConfigValue
 from .ast_nodes import ElifBlock, ForBlock, IfBlock, IOBlock, Plugin, Statement, Unknown
 from .config_parser import all_values, as_pairs, first_value
@@ -265,52 +267,13 @@ class _FlowContext(Protocol):
         append: bool = False,
     ) -> None: ...
 
+    def _assign_object_literal_subfields(
+        self, dest: str, pairs: list[ConfigPair], state: AnalyzerState, conditions: list[str], line: int, mode: str
+    ) -> None: ...
+
 
 class FlowExecutorMixin:
-    _PLUGIN_HANDLERS = {
-        "mutate": "_exec_mutate",
-        "json": "_exec_json",
-        "xml": "_exec_xml",
-        "kv": "_exec_kv",
-        "csv": "_exec_csv",
-        "grok": "_exec_grok",
-        "date": "_exec_date",
-        "base64": "_exec_base64",
-        "url_decode": "_exec_url_decode",
-        "syslog_pri": "_exec_syslog_pri",
-        "dissect": "_exec_dissect",
-        "on_error": "_exec_on_error_block",
-        "ruby": "_exec_ruby",
-        "translate": "_exec_translate",
-        "aggregate": "_exec_aggregate",
-        "clone": "_exec_clone",
-        "useragent": "_exec_useragent",
-        "geoip": "_exec_geoip",
-        "cidr": "_exec_generic_plugin",
-        "mac": "_exec_generic_transform",
-        "math": "_exec_generic_transform",
-        "extractnumbers": "_exec_generic_transform",
-        "tld": "_exec_generic_transform",
-        "cipher": "_exec_generic_transform",
-        "anonymize": "_exec_generic_transform",
-        "fingerprint": "_exec_generic_transform",
-        "urldecode": "_exec_generic_transform",
-        "bytes": "_exec_generic_transform",
-        "i18n": "_exec_generic_transform",
-        "alter": "_exec_generic_transform",
-        "truncate": "_exec_generic_transform",
-        "elapsed": "_exec_elapsed",
-        "uuid": "_exec_uuid",
-        "dns": "_exec_dns",
-        "prune": "_exec_prune",
-        "split": "_exec_split",
-        "elasticsearch": "_exec_external_lookup",
-        "memcached": "_exec_external_lookup",
-        "jdbc_streaming": "_exec_external_lookup",
-        "http": "_exec_external_lookup",
-        "rest": "_exec_external_lookup",
-        "acme_threat_lookup": "_exec_external_lookup",
-    }
+    _PLUGIN_HANDLERS = {name: spec.handler_name for name, spec in PLUGIN_SPECS.items()}
 
     def _exec_statements(
         self,
@@ -1373,7 +1336,8 @@ class FlowExecutorMixin:
         self, stmt: Plugin, state: AnalyzerState, conditions: list[str], depth: int = 0, loop_fanout: int = 1
     ) -> None:
         name = stmt.name
-        handler_name = self._PLUGIN_HANDLERS.get(name)
+        spec = plugin_spec_for(name)
+        handler_name = spec.handler_name if spec is not None and state.dialect in spec.dialects else None
         if name != "on_error":
             self._warn_config_advisories(stmt, state)
         if stmt.config_diagnostics and name != "on_error":
@@ -1391,7 +1355,12 @@ class FlowExecutorMixin:
                 block_handler(stmt, state, conditions, depth + 1, loop_fanout)
             else:
                 plugin_handler = cast(_PluginHandler, getattr(self, handler_name))
-                plugin_handler(stmt, state, conditions)
+                if spec is not None and spec.symbolic_failure_routing:
+                    self._exec_plugin_with_symbolic_failure(stmt, state, conditions, plugin_handler, spec)
+                else:
+                    plugin_handler(stmt, state, conditions)
+                    if spec is not None and spec.apply_decorators:
+                        self._apply_post_plugin_decorators(stmt, state, conditions)
             if name != "on_error":
                 cast(_FlowContext, self)._handle_on_error(stmt, state, conditions)
         elif name == "drop":
@@ -1470,6 +1439,59 @@ class FlowExecutorMixin:
             # per-token taints onto the specific destination fields the plugin
             # would have written, which we can usually infer from the config map.
             self._taint_unsupported_plugin_destinations(stmt, state, warning)
+
+    def _exec_plugin_with_symbolic_failure(
+        self,
+        stmt: Plugin,
+        state: AnalyzerState,
+        conditions: list[str],
+        plugin_handler: _PluginHandler,
+        spec: PluginSpec,
+    ) -> None:
+        failure_conditions = _dedupe_strings(conditions + [f"{stmt.name} failure"])
+
+        plugin_handler(stmt, state, conditions)
+        if spec.apply_decorators:
+            self._apply_post_plugin_decorators(stmt, state, conditions)
+        self._apply_failure_tags(stmt, state, failure_conditions, spec)
+
+    def _configured_string_list(self, stmt: Plugin, key: str, default: tuple[str, ...]) -> list[str]:
+        raw = first_value(stmt.config, key)
+        if raw is None:
+            return list(default)
+        if isinstance(raw, list) and not as_pairs(raw):
+            return [str(item) for item in raw if str(item)]
+        text = str(raw)
+        return [text] if text else []
+
+    def _failure_tags_for(self, stmt: Plugin, state: AnalyzerState, spec: PluginSpec) -> list[str]:
+        profile = dialect_profile_for(state.dialect)
+        default_failure = spec.default_failure_tags if profile.default_failure_tags_enabled else ()
+        default_timeout = spec.default_timeout_tags if profile.default_failure_tags_enabled else ()
+        tags = self._configured_string_list(stmt, "tag_on_failure", default_failure)
+        timeout_tags = self._configured_string_list(stmt, "tag_on_timeout", default_timeout)
+        on_error = first_value(stmt.config, "on_error")
+        if isinstance(on_error, str) and on_error:
+            tags.append(on_error)
+        return _dedupe_strings(tags + timeout_tags)
+
+    def _apply_failure_tags(
+        self, stmt: Plugin, state: AnalyzerState, conditions: list[str], spec: PluginSpec
+    ) -> None:
+        tags = self._failure_tags_for(stmt, state, spec)
+        if not tags:
+            return
+        loc = _location(stmt.line, stmt.name, "failure tags")
+        state.tag_state = state.tag_state.with_possible(tags, has_dynamic=False)
+        for tag in tags:
+            state.add_failure_tag_route(
+                FailureTagRoute(
+                    plugin=stmt.name,
+                    tag=tag,
+                    conditions=list(conditions),
+                    parser_locations=[loc],
+                )
+            )
 
     def _taint_unsupported_plugin_destinations(self, stmt: Plugin, state: AnalyzerState, warning: str) -> None:
         """Tag each destination written by an unsupported plugin with a scoped taint.
@@ -1574,12 +1596,17 @@ class FlowExecutorMixin:
 
     def _exec_ruby(self, stmt: Plugin, state: AnalyzerState, conditions: list[str]) -> None:
         """Executes a ruby block, using heuristic regex to model its effects."""
-        loc = _location(stmt.line, "ruby")
+        self._exec_ruby_like(stmt, state, conditions, kind="ruby", aggregate=False)
+
+    def _exec_ruby_like(
+        self, stmt: Plugin, state: AnalyzerState, conditions: list[str], *, kind: str, aggregate: bool
+    ) -> None:
+        loc = _location(stmt.line, kind)
 
         # 1. Collect ruby code
         code_snippets = []
         for key, value, _ in _iter_config_values(stmt.config):
-            if key in ("init", "code") and isinstance(value, str):
+            if key in ("init", "code", "timeout_code") and isinstance(value, str):
                 code_snippets.append(value)
 
         full_code = "\n".join(code_snippets)
@@ -1598,9 +1625,30 @@ class FlowExecutorMixin:
 
         # 3. Read Dependencies (`event.get(...)`)
         gets = re.findall(r"event\.get\(\s*['\"]([^'\"]+)['\"]\s*\)", full_code)
-        sources = [SourceRef(kind="ruby_get", source_token="ruby", path=g) for g in gets]  # nosec B106
+        gets.extend(re.findall(r"event\[['\"]([^'\"]+)['\"]\]", full_code))
+        map_reads = re.findall(r"map\[['\"]([^'\"]+)['\"]\]", full_code) if aggregate else []
+        sources = [SourceRef(kind=f"{kind}_get", source_token=kind, path=g) for g in gets]  # nosec B106
+        sources.extend(SourceRef(kind="aggregate_map", source_token=kind, path=m) for m in map_reads)
+        if "event.to_hash" in full_code:
+            sources.append(SourceRef(kind=f"{kind}_event_hash", source_token=kind, path="event.to_hash"))
         if not sources:
-            sources = [SourceRef(kind="ruby_block", source_token="ruby")]  # nosec B106
+            sources = [SourceRef(kind=f"{kind}_block", source_token=kind)]  # nosec B106
+
+        if aggregate:
+            for map_key, event_source in re.findall(
+                r"map\[['\"]([^'\"]+)['\"]\]\s*=\s*event\.get\(\s*['\"]([^'\"]+)['\"]\s*\)",
+                full_code,
+            ):
+                map_token = f"@metadata.aggregate.{map_key}"
+                map_lin = Lineage(
+                    status="dynamic",
+                    sources=[SourceRef(kind="aggregate_get", source_token=kind, path=event_source)],
+                    expression=map_token,
+                    transformations=["aggregate_map_write"],
+                    conditions=list(conditions),
+                    parser_locations=[loc],
+                )
+                cast(_FlowContext, self)._store_destination(map_token, [map_lin], loc, state, append=True)
 
         # 4. State Mutations (`event.set(...)`). Route through
         # ``_store_destination`` (append=True) so canonical normalization,
@@ -1615,15 +1663,41 @@ class FlowExecutorMixin:
                 status="dynamic",
                 sources=sources,
                 expression=normalized,
+                transformations=[f"{kind}_set"],
                 conditions=list(conditions),
                 parser_locations=[loc],
             )
             cast(_FlowContext, self)._store_destination(normalized, [ruby_lin], loc, state, append=True)
 
-        # 5. Event Splitting / Yielding (`yield` or `event.clone`)
-        if re.search(r"\byield\b", full_code) or ".clone" in full_code:
+        removes = re.findall(r"event\.remove\(\s*['\"]([^'\"]+)['\"]\s*\)", full_code)
+        if removes:
+            mutate_stmt = Plugin(stmt.line, "mutate", body="", config=[("remove_field", removes)])
+            cast(_PluginHandler, getattr(self, "_exec_mutate"))(mutate_stmt, state, conditions)  # noqa: B009
+
+        if re.search(r"\bevent\.cancel\b", full_code):
+            warning = f"{loc}: ruby event.cancel may drop events on this path"
+            state.add_warning(warning, code=f"{kind}_event_cancel", message=warning, parser_location=loc)
+            state.add_taint(f"{kind}_event_cancel", warning, loc)
+
+        if aggregate and self._truthy_config(stmt, "push_map_as_event_on_timeout"):
+            for map_key in _dedupe_strings(map_reads):
+                dest = _normalize_field_ref(map_key)
+                if not dest:
+                    continue
+                map_lin = Lineage(
+                    status="dynamic",
+                    sources=[SourceRef(kind="aggregate_map", source_token=kind, path=map_key)],
+                    expression=dest,
+                    transformations=["aggregate_timeout_flush"],
+                    conditions=_dedupe_strings(conditions + ["aggregate timeout flush"]),
+                    parser_locations=[loc],
+                )
+                cast(_FlowContext, self)._store_destination(dest, [map_lin], loc, state, append=True)
+
+        # 5. Event Splitting / Yielding (`yield`, `new_event_block.call`, or `event.clone`)
+        if re.search(r"\byield\b", full_code) or "new_event_block.call" in full_code or ".clone" in full_code:
             warning = ruby_event_split_warning(loc)
-            state.add_warning(warning, code="ruby_event_split", message=warning, parser_location=loc)
+            state.add_warning(warning, code=f"{kind}_event_split", message=warning, parser_location=loc)
             # No state fork required: the warning already conveys the
             # event-multiplication risk to consumers, and the previous code
             # merged two unmutated ``state.clone()`` copies into ``original``
@@ -1653,20 +1727,138 @@ class FlowExecutorMixin:
         if not dest_str:
             return
 
+        dictionary_pairs = self._translate_dictionary_pairs(stmt)
+        fallback = first_value(stmt.config, "fallback")
+        regex_mode = self._truthy_config(stmt, "regex") or not self._truthy_config(stmt, "exact", default=True)
+        dictionary_path = first_value(stmt.config, "dictionary_path")
+        transformations = ["translate"]
+        notes: list[str] = []
+        if dictionary_pairs:
+            transformations.append("translate_dictionary")
+            preview = ", ".join(f"{key!r}->{value!r}" for key, value in dictionary_pairs[:5])
+            if len(dictionary_pairs) > 5:
+                preview += ", ..."
+            notes.append(f"inline dictionary entries: {preview}")
+        if fallback is not None:
+            transformations.append("translate_fallback")
+            notes.append(f"fallback: {fallback!r}")
+        if regex_mode:
+            transformations.append("translate_regex")
+            notes.append("dictionary keys may be regex patterns")
+        if dictionary_path is not None:
+            transformations.append("translate_dictionary_path")
+            warning = f"{loc}: translate dictionary_path is runtime-loaded; dictionary values are not enumerated"
+            state.add_warning(
+                warning,
+                code="dynamic_translate_dictionary",
+                message=warning,
+                parser_location=loc,
+                source_token=str(dictionary_path),
+            )
+            state.add_taint("dynamic_translate_dictionary", warning, loc, str(dictionary_path))
+
         translate_lin = Lineage(
-            status="dynamic",
+            status="dynamic" if regex_mode or dictionary_path is not None else "derived",
             sources=sources,
-            expression=dest_str,
+            expression=f"translate({field!s})",
+            transformations=transformations,
             conditions=list(conditions),
             parser_locations=[loc],
+            notes=notes,
         )
         cast(_FlowContext, self)._store_destination(dest_str, [translate_lin], loc, state, append=True)
+        object_pairs = self._translate_object_projection_pairs(dictionary_pairs, fallback)
+        if object_pairs:
+            cast(_FlowContext, self)._assign_object_literal_subfields(
+                dest_str,
+                object_pairs,
+                state,
+                conditions,
+                stmt.line,
+                "translate",
+            )
         self._apply_post_plugin_decorators(stmt, state, conditions)
 
     def _exec_aggregate(self, stmt: Plugin, state: AnalyzerState, conditions: list[str]) -> None:
         """Executes an aggregate block (uses embedded ruby code)."""
-        # Aggregate blocks are essentially stateful ruby blocks. We model them the exact same way.
-        self._exec_ruby(stmt, state, conditions)
+        loc = _location(stmt.line, "aggregate")
+        warning = f"{loc}: aggregate uses shared state across events; modeled conservatively"
+        state.add_warning(warning, code="aggregate_state", message=warning, parser_location=loc)
+        state.add_taint("aggregate_state", warning, loc)
+        timeout_tags = first_value(stmt.config, "timeout_tags")
+        if isinstance(timeout_tags, list) and not as_pairs(timeout_tags):
+            tags = [str(tag) for tag in timeout_tags if str(tag)]
+            state.tag_state = state.tag_state.with_possible(tags, has_dynamic=False)
+            for tag in tags:
+                state.add_failure_tag_route(
+                    FailureTagRoute(
+                        plugin="aggregate",
+                        tag=tag,
+                        conditions=_dedupe_strings(conditions + ["aggregate timeout"]),
+                        parser_locations=[_location(stmt.line, "aggregate", "timeout_tags")],
+                    )
+                )
+        self._exec_ruby_like(stmt, state, conditions, kind="aggregate", aggregate=True)
+
+    def _truthy_config(self, stmt: Plugin, key: str, *, default: bool = False) -> bool:
+        value = first_value(stmt.config, key)
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes"}
+        return bool(value)
+
+    def _translate_dictionary_pairs(self, stmt: Plugin) -> list[tuple[str, str]]:
+        dictionary = first_value(stmt.config, "dictionary")
+        pairs = as_pairs(dictionary) if isinstance(dictionary, list) else []
+        return [(str(key), str(value)) for key, value in pairs]
+
+    def _translate_object_projection_pairs(
+        self, dictionary_pairs: list[tuple[str, str]], fallback: ConfigValue | None
+    ) -> list[ConfigPair]:
+        merged: dict[str, ConfigValue] = {}
+        for _key, value in dictionary_pairs:
+            for field, field_value in self._json_object_pairs(value):
+                merged.setdefault(field, field_value)
+        if fallback is not None:
+            for field, field_value in self._json_object_pairs(str(fallback)):
+                merged.setdefault(field, field_value)
+        return sorted(merged.items())
+
+    def _json_object_pairs(self, value: str) -> list[ConfigPair]:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(parsed, dict):
+            return []
+        pairs: list[ConfigPair] = []
+        for key, item in parsed.items():
+            if isinstance(item, dict):
+                pairs.append((str(key), [(str(k), self._json_scalar_to_config(v)) for k, v in sorted(item.items())]))
+            elif isinstance(item, list):
+                list_value: list[ConfigValue] = [str(v) if not isinstance(v, bool) else v for v in item]
+                pairs.append((str(key), list_value))
+            elif item is None:
+                pairs.append((str(key), "null"))
+            elif isinstance(item, bool):
+                pairs.append((str(key), item))
+            else:
+                pairs.append((str(key), str(item)))
+        return pairs
+
+    def _json_scalar_to_config(self, value: object) -> ConfigValue:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, list):
+            return [self._json_scalar_to_config(item) for item in value]
+        if isinstance(value, dict):
+            return [(str(k), self._json_scalar_to_config(v)) for k, v in sorted(value.items())]
+        if value is None:
+            return "null"
+        return str(value)
 
     def _exec_clone(self, stmt: Plugin, state: AnalyzerState, conditions: list[str]) -> None:
         """Executes a clone block."""
@@ -1738,7 +1930,8 @@ class FlowExecutorMixin:
     def _exec_enrichment_plugin(self, stmt: Plugin, state: AnalyzerState, conditions: list[str], kind: str) -> None:
         """Executes an enrichment plugin (like geoip or useragent) mapping source to target."""
         source = first_value(stmt.config, "source")
-        target = first_value(stmt.config, "target") or kind
+        target = first_value(stmt.config, "target") or first_value(stmt.config, "prefix") or kind
+        fields = first_value(stmt.config, "fields")
         loc = _location(stmt.line, kind)
 
         success_state = state.clone()
@@ -1750,10 +1943,25 @@ class FlowExecutorMixin:
                     status="dynamic",
                     sources=sources,
                     expression=dest_str,
+                    transformations=[kind],
                     conditions=list(conditions),
                     parser_locations=[loc],
                 )
                 cast(_FlowContext, self)._store_destination(dest_str, [lin], loc, success_state, append=True)
+                if isinstance(fields, list) and not as_pairs(fields):
+                    for field in fields:
+                        child = _normalize_field_ref(f"{dest_str}.{field}")
+                        if not child:
+                            continue
+                        child_lin = Lineage(
+                            status="dynamic",
+                            sources=sources,
+                            expression=child,
+                            transformations=[kind, "field_projection"],
+                            conditions=list(conditions),
+                            parser_locations=[loc],
+                        )
+                        cast(_FlowContext, self)._store_destination(child, [child_lin], loc, success_state, append=True)
 
         self._apply_post_plugin_decorators(stmt, success_state, conditions)
         state.merge_branch_records(
@@ -1812,6 +2020,12 @@ class FlowExecutorMixin:
         """Executes an external lookup plugin."""
         target = first_value(stmt.config, "target")
         loc = _location(stmt.line, stmt.name)
+        query_source = (
+            first_value(stmt.config, "query")
+            or first_value(stmt.config, "statement")
+            or first_value(stmt.config, "url")
+            or "external_query"
+        )
 
         success_state = state.clone()
         store = cast(_FlowContext, self)._store_destination
@@ -1820,8 +2034,9 @@ class FlowExecutorMixin:
             if dest_str:
                 lin = Lineage(
                     status="dynamic",
-                    sources=[SourceRef(kind=stmt.name, source_token=stmt.name, path="external_query")],
+                    sources=[SourceRef(kind=stmt.name, source_token=stmt.name, path=str(query_source))],
                     expression=dest_str,
+                    transformations=[stmt.name],
                     conditions=list(conditions),
                     parser_locations=[loc],
                 )
@@ -1832,9 +2047,10 @@ class FlowExecutorMixin:
         # Both lineages are real assignments (the lookup writes the row, the
         # ``get`` map projects fields onto the same path) and should both
         # survive deduplication thanks to distinct ``SourceRef.path`` values.
-        gets = all_values(stmt.config, "get")
-        for get_block in gets:
-            for src, tgt in as_pairs(get_block):
+        projections = [*all_values(stmt.config, "get"), *all_values(stmt.config, "fields")]
+        for get_block in projections:
+            projection_pairs = as_pairs(get_block)
+            for src, tgt in projection_pairs:
                 dest_str = _normalize_field_ref(str(tgt))
                 if not dest_str:
                     continue
@@ -1842,10 +2058,27 @@ class FlowExecutorMixin:
                     status="dynamic",
                     sources=[SourceRef(kind=stmt.name, source_token=stmt.name, path=str(src))],
                     expression=dest_str,
+                    transformations=[stmt.name, "field_projection"],
                     conditions=list(conditions),
                     parser_locations=[loc],
                 )
                 store(dest_str, [lin], loc, success_state, append=True)
+            if not projection_pairs and target and isinstance(get_block, list):
+                target_str = _normalize_field_ref(str(target))
+                if target_str:
+                    for field in get_block:
+                        child = _normalize_field_ref(f"{target_str}.{field}")
+                        if not child:
+                            continue
+                        lin = Lineage(
+                            status="dynamic",
+                            sources=[SourceRef(kind=stmt.name, source_token=stmt.name, path=str(field))],
+                            expression=child,
+                            transformations=[stmt.name, "field_projection"],
+                            conditions=list(conditions),
+                            parser_locations=[loc],
+                        )
+                        store(child, [lin], loc, success_state, append=True)
 
         self._apply_post_plugin_decorators(stmt, success_state, conditions)
         state.merge_branch_records(

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -1655,6 +1655,7 @@ class FlowExecutorMixin:
         # template-fanout caps, and dedup apply consistently with the rest
         # of the analyzer instead of the inline ``[]``→``.`` shortcut.
         sets = re.findall(r"event\.set\(\s*['\"]([^'\"]+)['\"]\s*,", full_code)
+        sets.extend(re.findall(r"event\[['\"]([^'\"]+)['\"]\]\s*=", full_code))
         for dest in sets:
             normalized = _normalize_field_ref(dest)
             if not normalized:

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -23,6 +23,7 @@ from ._analysis_diagnostics import (
     ruby_event_split_warning,
     runtime_condition_warning,
     static_limit_warning,
+    unknown_config_key_warning,
     unparsed_statement,
     unreachable_branch_warning,
     unsupported_plugin,
@@ -695,7 +696,24 @@ class FlowExecutorMixin:
             )
 
     def _warn_config_advisories(self, stmt: Plugin, state: AnalyzerState) -> None:
+        spec = plugin_spec_for(stmt.name)
         for key, value, _depth in _iter_config_values(stmt.config):
+            if (
+                _depth == 0
+                and spec is not None
+                and spec.config_model is None
+                and (spec.ignored_config_keys or spec.source_keys or spec.dest_keys)
+            ):
+                known_keys = {*spec.source_keys, *spec.dest_keys}
+                if key not in known_keys and not spec.ignores_config_key(key):
+                    warning = unknown_config_key_warning(stmt.line, stmt.name, key)
+                    state.add_warning(
+                        warning,
+                        code="unknown_config_key",
+                        message=warning,
+                        parser_location=_location(stmt.line, stmt.name),
+                        source_token=key,
+                    )
             if isinstance(value, list) and not as_pairs(value):
                 count = len(value)
                 if count > MAX_ARRAY_LITERAL_BEFORE_WARNING:
@@ -1337,7 +1355,21 @@ class FlowExecutorMixin:
     ) -> None:
         name = stmt.name
         spec = plugin_spec_for(name)
-        handler_name = spec.handler_name if spec is not None and state.dialect in spec.dialects else None
+        if spec is not None and state.dialect not in spec.dialects:
+            loc = _location(stmt.line, stmt.name)
+            dialects = ", ".join(spec.dialects)
+            warning = (
+                f"{loc}: plugin {stmt.name} is disabled for dialect {state.dialect}; supported dialects: {dialects}"
+            )
+            state.add_warning(
+                warning,
+                code="plugin_dialect_disabled",
+                message=warning,
+                parser_location=loc,
+                source_token=stmt.name,
+            )
+            return
+        handler_name = spec.handler_name if spec is not None else None
         if name != "on_error":
             self._warn_config_advisories(stmt, state)
         if stmt.config_diagnostics and name != "on_error":
@@ -1622,11 +1654,15 @@ class FlowExecutorMixin:
             state.add_taint("ruby_concurrency_risk", warning, loc, gv)
 
         # 3. Read Dependencies (`event.get(...)`)
-        gets = re.findall(r"event\.get\(\s*['\"]([^'\"]+)['\"]\s*\)", full_code)
-        gets.extend(re.findall(r"event\[['\"]([^'\"]+)['\"]\]", full_code))
-        map_reads = re.findall(r"map\[['\"]([^'\"]+)['\"]\]", full_code) if aggregate else []
-        sources = [SourceRef(kind=f"{kind}_get", source_token=kind, path=g) for g in gets]  # nosec B106
-        sources.extend(SourceRef(kind="aggregate_map", source_token=kind, path=m) for m in map_reads)
+        gets = re.findall(r"event\.get\s*\(?\s*['\"]([^'\"]+)['\"]\s*\)?", full_code)
+        gets.extend(re.findall(r"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*=)", full_code))
+        map_reads = re.findall(r"map\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*=)", full_code) if aggregate else []
+        sources = [  # nosec B106
+            SourceRef(kind=f"{kind}_get", source_token=kind, path=_normalize_field_ref(g)) for g in gets
+        ]
+        sources.extend(
+            SourceRef(kind="aggregate_map", source_token=kind, path=_normalize_field_ref(m)) for m in map_reads
+        )
         if "event.to_hash" in full_code:
             sources.append(SourceRef(kind=f"{kind}_event_hash", source_token=kind, path="event.to_hash"))
         if not sources:
@@ -1652,8 +1688,8 @@ class FlowExecutorMixin:
         # ``_store_destination`` (append=True) so canonical normalization,
         # template-fanout caps, and dedup apply consistently with the rest
         # of the analyzer instead of the inline ``[]``→``.`` shortcut.
-        sets = re.findall(r"event\.set\(\s*['\"]([^'\"]+)['\"]\s*,", full_code)
-        sets.extend(re.findall(r"event\[['\"]([^'\"]+)['\"]\]\s*=", full_code))
+        sets = re.findall(r"event\.set\s*\(?\s*['\"]([^'\"]+)['\"]\s*,", full_code)
+        sets.extend(re.findall(r"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\]\s*=", full_code))
         for dest in sets:
             normalized = _normalize_field_ref(dest)
             if not normalized:
@@ -1668,7 +1704,7 @@ class FlowExecutorMixin:
             )
             cast(_FlowContext, self)._store_destination(normalized, [ruby_lin], loc, state, append=True)
 
-        removes = re.findall(r"event\.remove\(\s*['\"]([^'\"]+)['\"]\s*\)", full_code)
+        removes = re.findall(r"event\.remove\s*\(?\s*['\"]([^'\"]+)['\"]\s*\)?", full_code)
         if removes:
             mutate_stmt = Plugin(stmt.line, "mutate", body="", config=[("remove_field", removes)])
             cast(_PluginHandler, getattr(self, "_exec_mutate"))(mutate_stmt, state, conditions)  # noqa: B009
@@ -1838,7 +1874,7 @@ class FlowExecutorMixin:
             if isinstance(item, dict):
                 pairs.append((str(key), [(str(k), self._json_scalar_to_config(v)) for k, v in sorted(item.items())]))
             elif isinstance(item, list):
-                list_value: list[ConfigValue] = [str(v) if not isinstance(v, bool) else v for v in item]
+                list_value: list[ConfigValue] = [self._json_scalar_to_config(v) for v in item]
                 pairs.append((str(key), list_value))
             elif item is None:
                 pairs.append((str(key), "null"))
@@ -1929,14 +1965,23 @@ class FlowExecutorMixin:
     def _exec_enrichment_plugin(self, stmt: Plugin, state: AnalyzerState, conditions: list[str], kind: str) -> None:
         """Executes an enrichment plugin (like geoip or useragent) mapping source to target."""
         source = first_value(stmt.config, "source")
-        target = first_value(stmt.config, "target") or first_value(stmt.config, "prefix") or kind
         fields = first_value(stmt.config, "fields")
         loc = _location(stmt.line, kind)
 
         success_state = state.clone()
         if source:
             sources = [SourceRef(kind=kind, source_token=kind, path=str(source))]
-            dest_str = _normalize_field_ref(str(target))
+            target_val = first_value(stmt.config, "target")
+            prefix_val = first_value(stmt.config, "prefix")
+            projection_mode = "target"
+            if target_val is not None:
+                dest_value = target_val
+            elif prefix_val is not None:
+                dest_value = prefix_val
+                projection_mode = "prefix"
+            else:
+                dest_value = kind
+            dest_str = _normalize_field_ref(str(dest_value))
             if dest_str:
                 lin = Lineage(
                     status="dynamic",
@@ -1949,7 +1994,10 @@ class FlowExecutorMixin:
                 cast(_FlowContext, self)._store_destination(dest_str, [lin], loc, success_state, append=True)
                 if isinstance(fields, list) and not as_pairs(fields):
                     for field in fields:
-                        child = _normalize_field_ref(f"{dest_str}.{field}")
+                        if projection_mode == "prefix":
+                            child = _normalize_field_ref(f"{dest_str}{field}")
+                        else:
+                            child = _normalize_field_ref(f"{dest_str}.{field}")
                         if not child:
                             continue
                         child_lin = Lineage(

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -1653,10 +1653,17 @@ class FlowExecutorMixin:
             )
             state.add_taint("ruby_concurrency_risk", warning, loc, gv)
 
+        assignment_op = r"(?:\|\|=|&&=|<<=|>>=|\*\*=|[+\-*/%&|^]?=)"
+
         # 3. Read Dependencies (`event.get(...)`)
         gets = re.findall(r"event\.get\s*\(?\s*['\"]([^'\"]+)['\"]\s*\)?", full_code)
-        gets.extend(re.findall(r"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*=)", full_code))
-        map_reads = re.findall(r"map\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*=)", full_code) if aggregate else []
+        gets.extend(re.findall(rf"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*{assignment_op})", full_code))
+        map_reads = (
+            re.findall(rf"map\s*\[\s*['\"]([^'\"]+)['\"]\s*\](?!\s*{assignment_op})", full_code) if aggregate else []
+        )
+        map_writes = (
+            re.findall(rf"map\s*\[\s*['\"]([^'\"]+)['\"]\s*\]\s*{assignment_op}", full_code) if aggregate else []
+        )
         sources = [  # nosec B106
             SourceRef(kind=f"{kind}_get", source_token=kind, path=_normalize_field_ref(g)) for g in gets
         ]
@@ -1670,7 +1677,8 @@ class FlowExecutorMixin:
 
         if aggregate:
             for map_key, event_source in re.findall(
-                r"map\[['\"]([^'\"]+)['\"]\]\s*=\s*event\.get\(\s*['\"]([^'\"]+)['\"]\s*\)",
+                rf"map\s*\[\s*['\"]([^'\"]+)['\"]\s*\]\s*{assignment_op}\s*"
+                r"event\.get\s*\(?\s*['\"]([^'\"]+)['\"]\s*\)?",
                 full_code,
             ):
                 map_token = f"@metadata.aggregate.{map_key}"
@@ -1689,7 +1697,7 @@ class FlowExecutorMixin:
         # template-fanout caps, and dedup apply consistently with the rest
         # of the analyzer instead of the inline ``[]``→``.`` shortcut.
         sets = re.findall(r"event\.set\s*\(?\s*['\"]([^'\"]+)['\"]\s*,", full_code)
-        sets.extend(re.findall(r"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\]\s*=", full_code))
+        sets.extend(re.findall(rf"event\s*\[\s*['\"]([^'\"]+)['\"]\s*\]\s*{assignment_op}", full_code))
         for dest in sets:
             normalized = _normalize_field_ref(dest)
             if not normalized:
@@ -1715,7 +1723,7 @@ class FlowExecutorMixin:
             state.add_taint(f"{kind}_event_cancel", warning, loc)
 
         if aggregate and self._truthy_config(stmt, "push_map_as_event_on_timeout"):
-            for map_key in _dedupe_strings(map_reads):
+            for map_key in _dedupe_strings([*map_reads, *map_writes]):
                 dest = _normalize_field_ref(map_key)
                 if not dest:
                     continue

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -1475,9 +1475,7 @@ class FlowExecutorMixin:
             tags.append(on_error)
         return _dedupe_strings(tags + timeout_tags)
 
-    def _apply_failure_tags(
-        self, stmt: Plugin, state: AnalyzerState, conditions: list[str], spec: PluginSpec
-    ) -> None:
+    def _apply_failure_tags(self, stmt: Plugin, state: AnalyzerState, conditions: list[str], spec: PluginSpec) -> None:
         tags = self._failure_tags_for(stmt, state, spec)
         if not tags:
             return

--- a/parser_lineage_analyzer/_analysis_query.py
+++ b/parser_lineage_analyzer/_analysis_query.py
@@ -396,6 +396,11 @@ class AnalysisQueryMixin:
             for item in unknown_config_keys
             if item.get("plugin") and item.get("key")
         )
+        dialect_disabled_plugin_counts = Counter(
+            warning.source_token
+            for warning in structured_warnings
+            if warning.code == "plugin_dialect_disabled" and warning.source_token
+        )
         dynamic_or_symbolic_codes = {
             code: count
             for code, count in sorted(warning_counts.items())
@@ -437,6 +442,7 @@ class AnalysisQueryMixin:
             "unsupported_plugin_counts": dict(sorted(unsupported_plugin_counts.items())),
             "unsupported_mutate_operation_counts": dict(sorted(unsupported_mutate_op_counts.items())),
             "unknown_config_key_counts": dict(sorted(unknown_config_key_counts.items())),
+            "dialect_disabled_plugin_counts": dict(sorted(dialect_disabled_plugin_counts.items())),
             "dynamic_or_symbolic_warning_counts": dynamic_or_symbolic_codes,
             "failure_tag_routes": failure_tag_routes[:limit],
             "affected_fields": affected_fields[:limit],

--- a/parser_lineage_analyzer/_analysis_query.py
+++ b/parser_lineage_analyzer/_analysis_query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from bisect import insort
 from collections import Counter
+from dataclasses import asdict
 from typing import Protocol, cast
 
 from ._analysis_helpers import (
@@ -19,6 +20,7 @@ from ._analysis_helpers import (
     _udm_suffixes,
 )
 from ._analysis_state import AnalyzerState
+from ._plugin_specs import PLUGIN_SPECS, dialect_profile_for
 from ._types import JSONDict, JSONValue
 from .model import (
     AnalysisSummaryDict,
@@ -34,10 +36,20 @@ from .model import (
 
 SUMMARY_SAMPLE_LIMIT = 50
 MAX_ANCHOR_CONDITIONED_COMPACT_MAPPINGS = 50_000
+_UNSUPPORTED_PLUGIN_RE = re.compile(r"unsupported plugin (?P<name>[A-Za-z0-9_.:-]+)")
+_UNSUPPORTED_MUTATE_OP_RE = re.compile(r"unsupported mutate operation (?P<op>[^:]+)$")
+_PARSER_LOCATION_PLUGIN_RE = re.compile(r"^line \d+:\s*(?P<plugin>[A-Za-z0-9_.:-]+)")
 
 
 def _clamp_query_sample_limit(sample_limit: int) -> int:
     return min(max(int(sample_limit), 0), SUMMARY_SAMPLE_LIMIT)
+
+
+def _compat_plugin_name(parser_location: str | None) -> str | None:
+    if parser_location is None:
+        return None
+    match = _PARSER_LOCATION_PLUGIN_RE.match(parser_location)
+    return match.group("plugin") if match else parser_location
 
 
 class _QueryContext(Protocol):
@@ -350,6 +362,97 @@ class AnalysisQueryMixin:
             "xml_extractions_total": totals["xml_extractions"],
         }
         return compact_summary
+
+    def compat_report(self, *, compact: bool = False) -> JSONDict:
+        """Return a dialect-oriented compatibility report for parser-corpus audits."""
+        state = cast(_QueryContext, self).analyze()
+        structured_warnings = _dedupe_warning_reasons(state.structured_warnings)
+        warning_counts = Counter(w.code for w in structured_warnings)
+        warning_counts.update(state._suppressed_warning_counts)
+        unsupported = _dedupe_strings(state.unsupported)
+
+        unsupported_plugins = [item for item in unsupported if "unsupported plugin" in item]
+        unsupported_mutate_ops = [item for item in unsupported if "unsupported mutate operation" in item]
+        unsupported_plugin_counts: Counter[str] = Counter()
+        for item in unsupported_plugins:
+            match = _UNSUPPORTED_PLUGIN_RE.search(item)
+            unsupported_plugin_counts[match.group("name") if match else item] += 1
+        unsupported_mutate_op_counts: Counter[str] = Counter()
+        for item in unsupported_mutate_ops:
+            match = _UNSUPPORTED_MUTATE_OP_RE.search(item)
+            unsupported_mutate_op_counts[match.group("op").strip() if match else item] += 1
+        unknown_config_keys = [
+            {
+                "plugin": _compat_plugin_name(warning.parser_location),
+                "parser_location": warning.parser_location,
+                "key": warning.source_token,
+                "message": warning.message,
+            }
+            for warning in structured_warnings
+            if warning.code == "unknown_config_key"
+        ]
+        unknown_config_key_counts = Counter(
+            f"{item.get('plugin')}.{item.get('key')}"
+            for item in unknown_config_keys
+            if item.get("plugin") and item.get("key")
+        )
+        dynamic_or_symbolic_codes = {
+            code: count
+            for code, count in sorted(warning_counts.items())
+            if code.startswith("dynamic_")
+            or code.startswith("runtime_")
+            or code in {"static_limit", "gsub_backreference", "template_fanout"}
+        }
+
+        failure_tag_routes: list[JSONDict] = [route.to_json() for route in state.failure_tag_routes]
+        affected_fields: list[str] = []
+        affected_field_counts: Counter[str] = Counter()
+        affected_seen: set[str] = set()
+        for token, lineages in state.tokens.items():
+            token_affected = False
+            for lin in lineages:
+                if lin.status in {"dynamic", "unresolved"} or lin.taints:
+                    token_affected = True
+                    affected_field_counts[token] += 1
+            if token_affected and token not in affected_seen:
+                affected_seen.add(token)
+                affected_fields.append(token)
+
+        limit = SUMMARY_SAMPLE_LIMIT if compact else None
+        affected_field_counts_sorted = sorted(affected_field_counts.items(), key=lambda item: (-item[1], item[0]))
+        report: JSONDict = {
+            "dialect": getattr(state, "dialect", "secops"),
+            "dialect_profile": asdict(dialect_profile_for(getattr(state, "dialect", "secops"))),
+            "mutate_canonical_order": state.mutate_canonical_order,
+            "plugin_registry": {
+                "built_in_plugins": len(PLUGIN_SPECS),
+                "semantic_class_counts": dict(
+                    sorted(Counter(spec.semantic_class for spec in PLUGIN_SPECS.values()).items())
+                ),
+            },
+            "unsupported_plugins": unsupported_plugins[:limit],
+            "unsupported_mutate_operations": unsupported_mutate_ops[:limit],
+            "unknown_config_keys": unknown_config_keys[:limit],
+            "warning_counts": dict(sorted(warning_counts.items())),
+            "unsupported_plugin_counts": dict(sorted(unsupported_plugin_counts.items())),
+            "unsupported_mutate_operation_counts": dict(sorted(unsupported_mutate_op_counts.items())),
+            "unknown_config_key_counts": dict(sorted(unknown_config_key_counts.items())),
+            "dynamic_or_symbolic_warning_counts": dynamic_or_symbolic_codes,
+            "failure_tag_routes": failure_tag_routes[:limit],
+            "affected_fields": affected_fields[:limit],
+            "affected_field_counts": dict(affected_field_counts_sorted[:limit]),
+            "totals": {
+                "unsupported_plugins": len(unsupported_plugins),
+                "unsupported_mutate_operations": len(unsupported_mutate_ops),
+                "unknown_config_keys": len(unknown_config_keys),
+                "failure_tag_routes": len(failure_tag_routes),
+                "affected_fields": len(affected_fields),
+                "dynamic_or_symbolic_warnings": sum(dynamic_or_symbolic_codes.values()),
+            },
+        }
+        if compact:
+            report["compact"] = {"limit": SUMMARY_SAMPLE_LIMIT}
+        return report
 
     def _summary_taint_sample_counts(self, state: AnalyzerState) -> tuple[list[JSONDict], int, dict[str, int]]:
         seen: set[tuple[object, ...]] = set()

--- a/parser_lineage_analyzer/_analysis_state.py
+++ b/parser_lineage_analyzer/_analysis_state.py
@@ -1219,8 +1219,6 @@ class AnalyzerState:
         if key in self._failure_tag_route_seen:
             return
         self._ensure_metadata_owned()
-        if key in self._failure_tag_route_seen:
-            return
         self._failure_tag_route_seen.add(key)
         self.failure_tag_routes.append(route)
 

--- a/parser_lineage_analyzer/_analysis_state.py
+++ b/parser_lineage_analyzer/_analysis_state.py
@@ -84,6 +84,14 @@ class TagState:
             has_dynamic=self.has_dynamic or has_dynamic,
         )
 
+    def with_possible(self, literals: Iterable[str], *, has_dynamic: bool) -> TagState:
+        lits = frozenset(literals)
+        return TagState(
+            definitely=self.definitely,
+            possibly=self.possibly | lits,
+            has_dynamic=self.has_dynamic or has_dynamic,
+        )
+
     def with_removed(self, literals: Iterable[str], *, has_dynamic: bool) -> TagState:
         lits = frozenset(literals)
         # Definitely-removed: drop from definitely. If the remove is purely
@@ -564,6 +572,45 @@ class ExtractionHint:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class FailureTagRoute:
+    plugin: str
+    tag: str
+    conditions: Iterable[str] = field(default_factory=tuple)
+    parser_locations: Iterable[str] = field(default_factory=tuple)
+    _analysis_key: tuple[object, ...] | None = field(default=None, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "conditions", tuple(self.conditions))
+        object.__setattr__(self, "parser_locations", tuple(self.parser_locations))
+        object.__setattr__(
+            self,
+            "_analysis_key",
+            (
+                self.plugin,
+                self.tag,
+                self.conditions,
+                self.parser_locations,
+            ),
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._analysis_key)
+
+    def __eq__(self, other: object) -> bool:
+        if other.__class__ is not FailureTagRoute:
+            return NotImplemented
+        return self._analysis_key == other._analysis_key
+
+    def to_json(self) -> JSONDict:
+        return {
+            "plugin": self.plugin,
+            "tag": self.tag,
+            "conditions": list(self.conditions),
+            "parser_locations": list(self.parser_locations),
+        }
+
+
 @dataclass
 class AnalyzerState:
     tokens: MutableMapping[str, list[Lineage]] = field(default_factory=dict)
@@ -573,6 +620,7 @@ class AnalyzerState:
     # mutate{} block are dispatched in Logstash's canonical order rather than
     # source order. False matches the analyzer's historical behavior.
     mutate_canonical_order: bool = False
+    dialect: str = "secops"
     # T2: structured tag-membership tracking — see TagState docstring. The
     # field is itself immutable; updates produce a new TagState assigned back.
     tag_state: TagState = field(default_factory=TagState)
@@ -580,6 +628,7 @@ class AnalyzerState:
     kv_extractions: list[ExtractionHint] = field(default_factory=list)
     csv_extractions: list[ExtractionHint] = field(default_factory=list)
     xml_extractions: list[ExtractionHint] = field(default_factory=list)
+    failure_tag_routes: list[FailureTagRoute] = field(default_factory=list)
     unsupported: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     structured_warnings: list[WarningReason] = field(default_factory=list)
@@ -658,8 +707,8 @@ class AnalyzerState:
     _diagnostic_base_counts: tuple[int, int, int, int, int] = field(
         default=(0, 0, 0, 0, 0), init=False, repr=False, compare=False
     )
-    _metadata_base_counts: tuple[int, int, int, int, int] = field(
-        default=(0, 0, 0, 0, 0), init=False, repr=False, compare=False
+    _metadata_base_counts: tuple[int, int, int, int, int, int] = field(
+        default=(0, 0, 0, 0, 0, 0), init=False, repr=False, compare=False
     )
     _metadata_owned: bool = field(default=True, init=False, repr=False, compare=False)
     _metadata_seen_owned: bool = field(default=True, init=False, repr=False, compare=False)
@@ -680,6 +729,7 @@ class AnalyzerState:
     )
     _output_anchor_seen: set[Key] = field(default_factory=set, init=False, repr=False, compare=False)
     _hint_seen_by_kind: dict[str, set[Key]] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _failure_tag_route_seen: set[Key] = field(default_factory=set, init=False, repr=False, compare=False)
     _token_lineage_key_cache: dict[str, AbstractSet[Key]] = field(
         default_factory=dict, init=False, repr=False, compare=False
     )
@@ -1164,6 +1214,16 @@ class AnalyzerState:
         self._extractor_hint_generation_by_kind[kind] = self._extractor_hint_generation_by_kind.get(kind, 0) + added
         self._has_resolved_extractor.pop(kind, None)
 
+    def add_failure_tag_route(self, route: FailureTagRoute) -> None:
+        key = cast(Key, route._analysis_key)
+        if key in self._failure_tag_route_seen:
+            return
+        self._ensure_metadata_owned()
+        if key in self._failure_tag_route_seen:
+            return
+        self._failure_tag_route_seen.add(key)
+        self.failure_tag_routes.append(route)
+
     def inference_generation_key(self) -> tuple[int, int, int, int]:
         return (
             self._extractor_hint_generation_by_kind.get("json", 0),
@@ -1283,6 +1343,7 @@ class AnalyzerState:
         self._hint_seen_by_kind = {
             kind: {_hint_key(hint) for hint in self._hints_for_kind(kind)} for kind in ("json", "kv", "csv", "xml")
         }
+        self._failure_tag_route_seen = {cast(Key, route._analysis_key) for route in self.failure_tag_routes}
         self._metadata_seen_owned = True
         self._extractor_hint_generation += 1
         self._extractor_hint_generation_by_kind = {
@@ -1301,10 +1362,12 @@ class AnalyzerState:
             self.kv_extractions = list(self.kv_extractions)
             self.csv_extractions = list(self.csv_extractions)
             self.xml_extractions = list(self.xml_extractions)
+            self.failure_tag_routes = list(self.failure_tag_routes)
             self._metadata_owned = True
         if not self._metadata_seen_owned:
             self._output_anchor_seen = set(self._output_anchor_seen)
             self._hint_seen_by_kind = {kind: set(keys) for kind, keys in self._hint_seen_by_kind.items()}
+            self._failure_tag_route_seen = set(self._failure_tag_route_seen)
             self._metadata_seen_owned = True
 
     def _ensure_diagnostics_owned(self) -> None:
@@ -1352,11 +1415,13 @@ class AnalyzerState:
             tokens={},
             output_anchors=self.output_anchors,
             mutate_canonical_order=self.mutate_canonical_order,
+            dialect=self.dialect,
             tag_state=self.tag_state,
             json_extractions=self.json_extractions,
             kv_extractions=self.kv_extractions,
             csv_extractions=self.csv_extractions,
             xml_extractions=self.xml_extractions,
+            failure_tag_routes=self.failure_tag_routes,
             unsupported=self.unsupported,
             warnings=self.warnings,
             structured_warnings=self.structured_warnings,
@@ -1403,6 +1468,7 @@ class AnalyzerState:
         clone._static_destination_total_tokens = self._static_destination_total_tokens
         clone._output_anchor_seen = self._output_anchor_seen
         clone._hint_seen_by_kind = self._hint_seen_by_kind
+        clone._failure_tag_route_seen = self._failure_tag_route_seen
         # Per-kind copy-on-write for the extractor hint index. Both parent and
         # clone share the outer dicts and inner buckets by reference; the next
         # call to ``_ensure_extractor_hint_index`` on either side shallow-copies
@@ -1449,6 +1515,7 @@ class AnalyzerState:
             len(self.kv_extractions),
             len(self.csv_extractions),
             len(self.xml_extractions),
+            len(self.failure_tag_routes),
         )
         clone._diagnostic_base_counts = (
             len(self.unsupported),
@@ -1756,7 +1823,7 @@ class AnalyzerState:
     def _merge_branch_metadata_delta(self, records: list[BranchRecord]) -> None:
         for record in records:
             state = record.state
-            a0, j0, k0, c0, x0 = state._metadata_base_counts
+            a0, j0, k0, c0, x0, f0 = state._metadata_base_counts
             # If the branch never took ownership of a metadata container, the
             # branch's reference is still aliased to the parent's list. The
             # branch-local delta is by definition empty in that case (any new
@@ -1777,6 +1844,9 @@ class AnalyzerState:
                 self.add_extraction_hints("csv", state.csv_extractions[c0:])
             if state.xml_extractions is not self.xml_extractions and len(state.xml_extractions) > x0:
                 self.add_extraction_hints("xml", state.xml_extractions[x0:])
+            if state.failure_tag_routes is not self.failure_tag_routes and len(state.failure_tag_routes) > f0:
+                for route in state.failure_tag_routes[f0:]:
+                    self.add_failure_tag_route(route)
 
     def _apply_dropped_path_conditions(
         self, survivors: list[AnalyzerState], dropped_records: list[BranchRecord], records: list[BranchRecord]

--- a/parser_lineage_analyzer/_plugin_config_models.py
+++ b/parser_lineage_analyzer/_plugin_config_models.py
@@ -57,6 +57,7 @@ class DatePluginConfig(_PluginConfig):  # type: ignore[explicit-any]
     match: list[object] | None = None
     target: str = "event.idm.read_only_udm.metadata.event_timestamp"
     timezone: str | None = None
+    locale: str | None = None
 
 
 class Base64PluginConfig(_PluginConfig):  # type: ignore[explicit-any]

--- a/parser_lineage_analyzer/_plugin_signatures.py
+++ b/parser_lineage_analyzer/_plugin_signatures.py
@@ -179,9 +179,8 @@ class PluginSignatureRegistry:
 
         Files are loaded in sorted order so two directories with the
         same files produce the same registry state. Missing or non-
-        directory paths are silently ignored — the bundled
-        ``plugin_signatures/`` directory ships empty in v0.2 so callers
-        can opt into "load bundled if present" without guarding.
+        directory paths are silently ignored so callers can opt into
+        "load bundled if present" without guarding.
 
         Symlinks whose resolved target sits outside the loaded directory
         are skipped: a configured signatures directory shouldn't
@@ -260,10 +259,9 @@ class PluginSignatureRegistry:
 def load_bundled_registry() -> PluginSignatureRegistry:
     """Load any signatures bundled with the package.
 
-    v0.2 ships the ``plugin_signatures/`` directory empty (see
-    ``docs/plugin-signatures.md`` for examples that are deliberately
-    docs-only). The loader still consults the directory so future
-    bundled additions need no code change.
+    The bundled directory contains conservative audited signatures for
+    common opaque enrichers. Callers opt in by invoking this loader (or by
+    passing the directory through the existing CLI/plugin-signature path).
     """
     registry = PluginSignatureRegistry()
     bundled_dir = Path(__file__).parent / "plugin_signatures"

--- a/parser_lineage_analyzer/_plugin_specs.py
+++ b/parser_lineage_analyzer/_plugin_specs.py
@@ -247,6 +247,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
         runtime_notes=("Ruby is modeled by conservative event API patterns only",),
     ),
     "translate": PluginSpec(
+
         "_exec_translate",
         semantic_class="transform",
         source_keys=("field", "source"),
@@ -395,7 +396,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "elasticsearch": PluginSpec(
         "_exec_external_lookup",
-        dialects=("logstash",),
+
         semantic_class="enricher",
         source_keys=("query", "statement", "url"),
         dest_keys=("target", "get", "fields"),
@@ -420,7 +421,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "memcached": PluginSpec(
         "_exec_external_lookup",
-        dialects=("logstash",),
+
         semantic_class="enricher",
         dest_keys=("target", "get"),
         dest_value_kind="map",
@@ -429,7 +430,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "jdbc_streaming": PluginSpec(
         "_exec_external_lookup",
-        dialects=("logstash",),
+
         semantic_class="enricher",
         source_keys=("statement",),
         dest_keys=("target",),
@@ -449,7 +450,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "http": PluginSpec(
         "_exec_external_lookup",
-        dialects=("logstash",),
+
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),
@@ -458,7 +459,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "rest": PluginSpec(
         "_exec_external_lookup",
-        dialects=("logstash",),
+
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),

--- a/parser_lineage_analyzer/_plugin_specs.py
+++ b/parser_lineage_analyzer/_plugin_specs.py
@@ -114,9 +114,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
         semantic_class="extractor",
         source_keys=("source",),
         dest_keys=("target",),
-        ignored_config_keys=frozenset(
-            {"force_array", "parse_options", "remove_namespaces", "store_xml", "target"}
-        ),
+        ignored_config_keys=frozenset({"force_array", "parse_options", "remove_namespaces", "store_xml", "target"}),
         default_failure_tags=("_xmlparsefailure",),
         apply_decorators=True,
         symbolic_failure_routing=True,
@@ -247,7 +245,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
         runtime_notes=("Ruby is modeled by conservative event API patterns only",),
     ),
     "translate": PluginSpec(
-
         "_exec_translate",
         semantic_class="transform",
         source_keys=("field", "source"),
@@ -396,7 +393,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "elasticsearch": PluginSpec(
         "_exec_external_lookup",
-
         semantic_class="enricher",
         source_keys=("query", "statement", "url"),
         dest_keys=("target", "get", "fields"),
@@ -421,7 +417,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "memcached": PluginSpec(
         "_exec_external_lookup",
-
         semantic_class="enricher",
         dest_keys=("target", "get"),
         dest_value_kind="map",
@@ -430,7 +425,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "jdbc_streaming": PluginSpec(
         "_exec_external_lookup",
-
         semantic_class="enricher",
         source_keys=("statement",),
         dest_keys=("target",),
@@ -450,7 +444,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "http": PluginSpec(
         "_exec_external_lookup",
-
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),
@@ -459,7 +452,6 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "rest": PluginSpec(
         "_exec_external_lookup",
-
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),

--- a/parser_lineage_analyzer/_plugin_specs.py
+++ b/parser_lineage_analyzer/_plugin_specs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast
 
 from ._plugin_config_models import (
     Base64PluginConfig,
@@ -393,6 +393,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "elasticsearch": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         source_keys=("query", "statement", "url"),
         dest_keys=("target", "get", "fields"),
@@ -417,6 +418,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "memcached": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         dest_keys=("target", "get"),
         dest_value_kind="map",
@@ -425,6 +427,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "jdbc_streaming": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         source_keys=("statement",),
         dest_keys=("target",),
@@ -444,6 +447,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "http": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),
@@ -452,6 +456,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "rest": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         source_keys=("url",),
         dest_keys=("target",),
@@ -460,6 +465,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
     ),
     "acme_threat_lookup": PluginSpec(
         "_exec_external_lookup",
+        dialects=("logstash",),
         semantic_class="enricher",
         dest_keys=("target",),
         taint_hint="dynamic",
@@ -470,7 +476,7 @@ PLUGIN_SPECS: dict[str, PluginSpec] = {
 def normalize_dialect(dialect: str) -> ParserDialect:
     if dialect not in {"secops", "logstash"}:
         raise ValueError(f"dialect must be 'secops' or 'logstash', got {dialect!r}")
-    return dialect  # type: ignore[return-value]
+    return cast(ParserDialect, dialect)
 
 
 def dialect_profile_for(dialect: str) -> DialectProfile:

--- a/parser_lineage_analyzer/_plugin_specs.py
+++ b/parser_lineage_analyzer/_plugin_specs.py
@@ -1,0 +1,512 @@
+"""Compatibility metadata for built-in parser plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from ._plugin_config_models import (
+    Base64PluginConfig,
+    CsvPluginConfig,
+    DatePluginConfig,
+    DissectPluginConfig,
+    GrokPluginConfig,
+    JsonPluginConfig,
+    KvPluginConfig,
+    UrlDecodePluginConfig,
+    XmlPluginConfig,
+)
+
+ParserDialect = Literal["secops", "logstash"]
+PluginSemanticClass = Literal["extractor", "enricher", "transform", "mutate_like", "passthrough"]
+DestinationValueKind = Literal["scalar", "map", "list"]
+TaintHint = Literal["none", "derived", "dynamic"]
+GENERIC_TRANSFORM_SOURCE_KEYS = ("source", "field", "fields")
+GENERIC_TRANSFORM_DEST_KEYS = ("target",)
+
+
+@dataclass(frozen=True, slots=True)
+class DialectProfile:
+    name: ParserDialect
+    mutate_canonical_order_default: bool
+    supports_on_error_blocks: bool
+    default_failure_tags_enabled: bool
+    warn_unknown_config_keys: bool
+    statedump_is_terminal: bool
+    io_anchor_mode: Literal["secops", "logstash"]
+
+
+DIALECT_PROFILES: dict[ParserDialect, DialectProfile] = {
+    "secops": DialectProfile(
+        name="secops",
+        mutate_canonical_order_default=False,
+        supports_on_error_blocks=True,
+        default_failure_tags_enabled=False,
+        warn_unknown_config_keys=True,
+        statedump_is_terminal=True,
+        io_anchor_mode="secops",
+    ),
+    "logstash": DialectProfile(
+        name="logstash",
+        mutate_canonical_order_default=True,
+        supports_on_error_blocks=False,
+        default_failure_tags_enabled=True,
+        warn_unknown_config_keys=True,
+        statedump_is_terminal=False,
+        io_anchor_mode="logstash",
+    ),
+}
+
+COMMON_IGNORED_CONFIG_KEYS = frozenset(
+    {
+        "add_field",
+        "add_tag",
+        "enable_metric",
+        "id",
+        "on_error",
+        "periodic_flush",
+        "remove_field",
+        "remove_tag",
+        "tag_on_failure",
+        "tag_on_timeout",
+        "timeout_millis",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PluginSpec:
+    handler_name: str
+    dialects: tuple[ParserDialect, ...] = ("secops", "logstash")
+    config_model: type[object] | None = None
+    semantic_class: PluginSemanticClass = "passthrough"
+    source_keys: tuple[str, ...] = ()
+    dest_keys: tuple[str, ...] = ()
+    dest_value_kind: DestinationValueKind = "scalar"
+    taint_hint: TaintHint = "none"
+    runtime_notes: tuple[str, ...] = ()
+    ignored_config_keys: frozenset[str] = field(default_factory=frozenset)
+    default_failure_tags: tuple[str, ...] = ()
+    default_timeout_tags: tuple[str, ...] = ()
+    apply_decorators: bool = False
+    symbolic_failure_routing: bool = False
+
+    def ignores_config_key(self, key: str) -> bool:
+        return key in COMMON_IGNORED_CONFIG_KEYS or key in self.ignored_config_keys
+
+
+PLUGIN_SPECS: dict[str, PluginSpec] = {
+    "mutate": PluginSpec("_exec_mutate", semantic_class="mutate_like"),
+    "json": PluginSpec(
+        "_exec_json",
+        config_model=JsonPluginConfig,
+        semantic_class="extractor",
+        source_keys=("source",),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset({"fallback", "skip_on_invalid_json"}),
+        default_failure_tags=("_jsonparsefailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "xml": PluginSpec(
+        "_exec_xml",
+        config_model=XmlPluginConfig,
+        semantic_class="extractor",
+        source_keys=("source",),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset(
+            {"force_array", "parse_options", "remove_namespaces", "store_xml", "target"}
+        ),
+        default_failure_tags=("_xmlparsefailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "kv": PluginSpec(
+        "_exec_kv",
+        config_model=KvPluginConfig,
+        semantic_class="extractor",
+        source_keys=("source",),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset(
+            {
+                "allow_empty_values",
+                "default_keys",
+                "exclude_keys",
+                "field_split_pattern",
+                "include_brackets",
+                "include_keys",
+                "recursive",
+                "target",
+                "transform_key",
+                "transform_value",
+                "value_split_pattern",
+                "whitespace_strict",
+            }
+        ),
+        default_failure_tags=("_kvparsefailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "csv": PluginSpec(
+        "_exec_csv",
+        config_model=CsvPluginConfig,
+        semantic_class="extractor",
+        source_keys=("source",),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset(
+            {
+                "autodetect_column_names",
+                "autogenerate_column_names",
+                "convert",
+                "quote_char",
+                "skip_empty_columns",
+                "skip_empty_rows",
+                "skip_header",
+                "target",
+            }
+        ),
+        default_failure_tags=("_csvparsefailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "grok": PluginSpec(
+        "_exec_grok",
+        config_model=GrokPluginConfig,
+        semantic_class="extractor",
+        source_keys=("match", "source"),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset(
+            {
+                "break_on_match",
+                "keep_empty_captures",
+                "named_captures_only",
+                "overwrite",
+                "source",
+                "target",
+            }
+        ),
+        default_failure_tags=("_grokparsefailure",),
+        default_timeout_tags=("_groktimeout",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "date": PluginSpec(
+        "_exec_date",
+        config_model=DatePluginConfig,
+        semantic_class="transform",
+        source_keys=("match", "timezone"),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset({"locale", "match", "target", "timezone"}),
+        default_failure_tags=("_dateparsefailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "base64": PluginSpec(
+        "_exec_base64",
+        config_model=Base64PluginConfig,
+        semantic_class="transform",
+        source_keys=("source", "field", "fields"),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset({"action"}),
+        apply_decorators=True,
+    ),
+    "url_decode": PluginSpec(
+        "_exec_url_decode",
+        config_model=UrlDecodePluginConfig,
+        semantic_class="transform",
+        source_keys=("source", "field", "fields"),
+        dest_keys=("target",),
+        apply_decorators=True,
+    ),
+    "syslog_pri": PluginSpec(
+        "_exec_syslog_pri",
+        semantic_class="transform",
+        source_keys=("source",),
+        apply_decorators=True,
+    ),
+    "dissect": PluginSpec(
+        "_exec_dissect",
+        config_model=DissectPluginConfig,
+        semantic_class="extractor",
+        source_keys=("mapping", "match"),
+        ignored_config_keys=frozenset({"append_separator", "convert_datatype"}),
+        default_failure_tags=("_dissectfailure",),
+        apply_decorators=True,
+        symbolic_failure_routing=True,
+    ),
+    "on_error": PluginSpec(
+        "_exec_on_error_block",
+        dialects=("secops",),
+        runtime_notes=("SecOps-only fallback block",),
+    ),
+    "ruby": PluginSpec(
+        "_exec_ruby",
+        semantic_class="transform",
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset({"code", "init", "path", "script_params"}),
+        runtime_notes=("Ruby is modeled by conservative event API patterns only",),
+    ),
+    "translate": PluginSpec(
+        "_exec_translate",
+        semantic_class="transform",
+        source_keys=("field", "source"),
+        dest_keys=("destination", "target"),
+        ignored_config_keys=frozenset(
+            {
+                "destination",
+                "dictionary",
+                "dictionary_path",
+                "exact",
+                "fallback",
+                "field",
+                "iterate_on",
+                "override",
+                "refresh_behaviour",
+                "refresh_interval",
+                "regex",
+                "source",
+                "target",
+                "yaml_dictionary_code_point_limit",
+            }
+        ),
+    ),
+    "aggregate": PluginSpec(
+        "_exec_aggregate",
+        semantic_class="transform",
+        source_keys=("task_id",),
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset(
+            {
+                "aggregate_maps_path",
+                "code",
+                "end_of_task",
+                "inactivity_timeout",
+                "map_action",
+                "push_map_as_event_on_timeout",
+                "push_previous_map_as_event",
+                "task_id",
+                "timeout",
+                "timeout_code",
+                "timeout_tags",
+            }
+        ),
+    ),
+    "clone": PluginSpec("_exec_clone", semantic_class="mutate_like", dest_keys=("clones",)),
+    "useragent": PluginSpec(
+        "_exec_useragent",
+        semantic_class="enricher",
+        source_keys=("source",),
+        dest_keys=("target", "prefix"),
+        ignored_config_keys=frozenset(
+            {"cache_size", "ecs_compatibility", "lru_cache_size", "prefix", "source", "target"}
+        ),
+    ),
+    "geoip": PluginSpec(
+        "_exec_geoip",
+        semantic_class="enricher",
+        source_keys=("source",),
+        dest_keys=("target",),
+        ignored_config_keys=frozenset(
+            {"database", "default_database_type", "ecs_compatibility", "fields", "source", "target"}
+        ),
+    ),
+    "cidr": PluginSpec("_exec_generic_plugin", semantic_class="enricher", taint_hint="dynamic"),
+    "mac": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "math": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "extractnumbers": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "tld": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "cipher": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "anonymize": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "fingerprint": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "urldecode": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "bytes": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "i18n": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "alter": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "truncate": PluginSpec(
+        "_exec_generic_transform",
+        semantic_class="transform",
+        source_keys=GENERIC_TRANSFORM_SOURCE_KEYS,
+        dest_keys=GENERIC_TRANSFORM_DEST_KEYS,
+    ),
+    "elapsed": PluginSpec("_exec_elapsed", semantic_class="transform"),
+    "uuid": PluginSpec("_exec_uuid", semantic_class="transform"),
+    "dns": PluginSpec("_exec_dns", semantic_class="enricher", taint_hint="dynamic"),
+    "prune": PluginSpec("_exec_prune", semantic_class="mutate_like", taint_hint="dynamic"),
+    "split": PluginSpec(
+        "_exec_split",
+        semantic_class="mutate_like",
+        source_keys=("field",),
+        dest_keys=("target",),
+    ),
+    "elasticsearch": PluginSpec(
+        "_exec_external_lookup",
+        dialects=("logstash",),
+        semantic_class="enricher",
+        source_keys=("query", "statement", "url"),
+        dest_keys=("target", "get", "fields"),
+        dest_value_kind="map",
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset(
+            {
+                "aggregation_fields",
+                "docinfo_fields",
+                "enable_sort",
+                "fields",
+                "get",
+                "hosts",
+                "index",
+                "query",
+                "result_size",
+                "sort",
+                "target",
+                "user",
+            }
+        ),
+    ),
+    "memcached": PluginSpec(
+        "_exec_external_lookup",
+        dialects=("logstash",),
+        semantic_class="enricher",
+        dest_keys=("target", "get"),
+        dest_value_kind="map",
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset({"get", "hosts", "namespace", "target", "ttl"}),
+    ),
+    "jdbc_streaming": PluginSpec(
+        "_exec_external_lookup",
+        dialects=("logstash",),
+        semantic_class="enricher",
+        source_keys=("statement",),
+        dest_keys=("target",),
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset(
+            {
+                "jdbc_driver_class",
+                "jdbc_driver_library",
+                "jdbc_password",
+                "jdbc_user",
+                "parameters",
+                "statement",
+                "target",
+                "use_cache",
+            }
+        ),
+    ),
+    "http": PluginSpec(
+        "_exec_external_lookup",
+        dialects=("logstash",),
+        semantic_class="enricher",
+        source_keys=("url",),
+        dest_keys=("target",),
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset({"body", "headers", "method", "target", "url", "verb"}),
+    ),
+    "rest": PluginSpec(
+        "_exec_external_lookup",
+        dialects=("logstash",),
+        semantic_class="enricher",
+        source_keys=("url",),
+        dest_keys=("target",),
+        taint_hint="dynamic",
+        ignored_config_keys=frozenset({"body", "headers", "method", "target", "url", "verb"}),
+    ),
+    "acme_threat_lookup": PluginSpec(
+        "_exec_external_lookup",
+        semantic_class="enricher",
+        dest_keys=("target",),
+        taint_hint="dynamic",
+    ),
+}
+
+
+def normalize_dialect(dialect: str) -> ParserDialect:
+    if dialect not in {"secops", "logstash"}:
+        raise ValueError(f"dialect must be 'secops' or 'logstash', got {dialect!r}")
+    return dialect  # type: ignore[return-value]
+
+
+def dialect_profile_for(dialect: str) -> DialectProfile:
+    return DIALECT_PROFILES[normalize_dialect(dialect)]
+
+
+def plugin_spec_for(name: str) -> PluginSpec | None:
+    return PLUGIN_SPECS.get(name)
+
+
+def config_key_is_ignored(plugin_name: str, key: str) -> bool:
+    spec = plugin_spec_for(plugin_name)
+    if spec is not None:
+        return spec.ignores_config_key(key)
+    return key in COMMON_IGNORED_CONFIG_KEYS
+
+
+__all__ = [
+    "COMMON_IGNORED_CONFIG_KEYS",
+    "DIALECT_PROFILES",
+    "DestinationValueKind",
+    "DialectProfile",
+    "PLUGIN_SPECS",
+    "ParserDialect",
+    "PluginSemanticClass",
+    "PluginSpec",
+    "TaintHint",
+    "config_key_is_ignored",
+    "dialect_profile_for",
+    "normalize_dialect",
+    "plugin_spec_for",
+]

--- a/parser_lineage_analyzer/_plugins_extractors.py
+++ b/parser_lineage_analyzer/_plugins_extractors.py
@@ -51,6 +51,7 @@ from ._plugin_config_models import (
     XmlPluginConfig,
     compact_validation_error,
 )
+from ._plugin_specs import config_key_is_ignored
 from ._regex_algebra import MAX_REGEX_BODY_BYTES
 from ._types import ConfigValue
 from .ast_nodes import Plugin
@@ -265,6 +266,8 @@ class ExtractorPluginMixin:
             if str(key) == "on_error":
                 continue
             if str(key) not in validation_data:
+                if config_key_is_ignored(stmt.name, str(key)):
+                    continue
                 validation_data[str(key)] = value
         try:
             return model_cls.model_validate(validation_data)
@@ -272,6 +275,8 @@ class ExtractorPluginMixin:
             extra_errors = [err for err in exc.errors() if err.get("type") == "extra_forbidden"]
             for err in extra_errors:
                 key = ".".join(str(part) for part in err.get("loc", ())) or "config"
+                if config_key_is_ignored(stmt.name, key):
+                    continue
                 warning = unknown_config_key_warning(stmt.line, stmt.name, key)
                 state.add_warning(
                     warning,

--- a/parser_lineage_analyzer/_plugins_mutate.py
+++ b/parser_lineage_analyzer/_plugins_mutate.py
@@ -114,6 +114,7 @@ class MutatePluginMixin:
         "convert": "_exec_convert_mutate_op",
         "lowercase": "_exec_case_mutate_op",
         "uppercase": "_exec_case_mutate_op",
+        "strip": "_exec_case_mutate_op",
         "gsub": "_exec_gsub_mutate_op",
         "split": "_exec_split_mutate_op",
         "join": "_exec_join_mutate_op",
@@ -144,10 +145,10 @@ class MutatePluginMixin:
     # purposes. The cross-block alternative was investigated and rejected
     # because no real fixture demonstrated the need; revisit only if a
     # corpus fixture surfaces a per-pipeline-ordering bug.
-    # C6: ``coerce`` and ``strip`` are not in ``_MUTATE_OP_HANDLERS`` (the
-    # analyzer doesn't implement them yet). Listing them here made
+    # C6: ``coerce`` is not in ``_MUTATE_OP_HANDLERS`` (the analyzer doesn't
+    # implement it yet). Listing it here made
     # ``_warn_mutate_ordering_drift`` skip drift checks whenever a parser
-    # mixed ``coerce``/``strip`` with supported ops, and the
+    # mixed ``coerce`` with supported ops, and the
     # ``--mutate-canonical-order`` flag would sort them into a canonical
     # position only to immediately emit ``unsupported_mutate_operation``.
     # Drop them from the canonical tuple until handlers exist; ordering for
@@ -160,6 +161,7 @@ class MutatePluginMixin:
         "gsub",
         "uppercase",
         "lowercase",
+        "strip",
         "remove_field",
         "split",
         "join",

--- a/parser_lineage_analyzer/_plugins_transforms.py
+++ b/parser_lineage_analyzer/_plugins_transforms.py
@@ -107,7 +107,10 @@ class TransformPluginMixin:
         timezone_raw = self._first_transform_config_value(stmt, state, "timezone")
         locale_raw = self._first_transform_config_value(stmt, state, "locale")
         config = self._validate_transform_config_model(
-            stmt, state, DatePluginConfig, {"match": match_raw, "target": target_raw, "timezone": timezone_raw}
+            stmt,
+            state,
+            DatePluginConfig,
+            {"match": match_raw, "target": target_raw, "timezone": timezone_raw, "locale": locale_raw},
         )
         match_is_map = isinstance(match_raw, list) and bool(as_pairs(match_raw))
         match = (
@@ -121,6 +124,7 @@ class TransformPluginMixin:
             else (target_raw if isinstance(target_raw, str) else "event.idm.read_only_udm.metadata.event_timestamp")
         )
         timezone = config.timezone if config is not None else (timezone_raw if isinstance(timezone_raw, str) else None)
+        locale = config.locale if config is not None else (locale_raw if isinstance(locale_raw, str) else None)
         loc = _location(stmt.line, "date", f"target={target}")
         if "%{" in str(target):
             warning = static_limit_warning(loc, f"dynamic date target {target}")
@@ -136,8 +140,8 @@ class TransformPluginMixin:
             transforms = [f"date({', '.join(formats)})"]
             if timezone is not None:
                 transforms.append(f"timezone({timezone})")
-            if locale_raw is not None:
-                transforms.append(f"locale({locale_raw})")
+            if locale is not None:
+                transforms.append(f"locale({locale})")
             lins = [
                 lin.with_transform(" ".join(transforms), loc)
                 for lin in context._resolve_token(source_token, state, loc)

--- a/parser_lineage_analyzer/_plugins_transforms.py
+++ b/parser_lineage_analyzer/_plugins_transforms.py
@@ -17,6 +17,7 @@ from ._analysis_diagnostics import (
 from ._analysis_helpers import _add_conditions, _flatten_scalars, _location, _normalize_field_ref
 from ._analysis_state import AnalyzerState
 from ._plugin_config_models import Base64PluginConfig, DatePluginConfig, UrlDecodePluginConfig, compact_validation_error
+from ._plugin_specs import config_key_is_ignored
 from ._types import ConfigValue
 from .ast_nodes import Plugin
 from .config_parser import all_values, as_pairs
@@ -64,6 +65,8 @@ class TransformPluginMixin:
             if str(key) == "on_error":
                 continue
             if str(key) not in validation_data:
+                if config_key_is_ignored(stmt.name, str(key)):
+                    continue
                 validation_data[str(key)] = value
         try:
             return model_cls.model_validate(validation_data)
@@ -71,6 +74,8 @@ class TransformPluginMixin:
             extra_errors = [err for err in exc.errors() if err.get("type") == "extra_forbidden"]
             for err in extra_errors:
                 key = ".".join(str(part) for part in err.get("loc", ())) or "config"
+                if config_key_is_ignored(stmt.name, key):
+                    continue
                 warning = unknown_config_key_warning(stmt.line, stmt.name, key)
                 state.add_warning(
                     warning,
@@ -100,6 +105,7 @@ class TransformPluginMixin:
             stmt, state, "target", "event.idm.read_only_udm.metadata.event_timestamp"
         )
         timezone_raw = self._first_transform_config_value(stmt, state, "timezone")
+        locale_raw = self._first_transform_config_value(stmt, state, "locale")
         config = self._validate_transform_config_model(
             stmt, state, DatePluginConfig, {"match": match_raw, "target": target_raw, "timezone": timezone_raw}
         )
@@ -116,6 +122,10 @@ class TransformPluginMixin:
         )
         timezone = config.timezone if config is not None else (timezone_raw if isinstance(timezone_raw, str) else None)
         loc = _location(stmt.line, "date", f"target={target}")
+        if "%{" in str(target):
+            warning = static_limit_warning(loc, f"dynamic date target {target}")
+            state.add_warning(warning, code="dynamic_date_target", message=warning, parser_location=loc)
+            state.add_taint("dynamic_date_target", f"date target {target!r} is runtime-dependent", loc)
         if timezone is not None and "%{" in str(timezone):
             warning = static_limit_warning(loc, f"dynamic date timezone {timezone}")
             state.add_warning(warning, code="dynamic_date_timezone", message=warning, parser_location=loc)
@@ -123,8 +133,13 @@ class TransformPluginMixin:
         if isinstance(match, list) and match:
             source_token = str(match[0])
             formats = [str(x) for x in _flatten_scalars(match[1:])]
+            transforms = [f"date({', '.join(formats)})"]
+            if timezone is not None:
+                transforms.append(f"timezone({timezone})")
+            if locale_raw is not None:
+                transforms.append(f"locale({locale_raw})")
             lins = [
-                lin.with_transform(f"date({', '.join(formats)})", loc)
+                lin.with_transform(" ".join(transforms), loc)
                 for lin in context._resolve_token(source_token, state, loc)
             ]
             lins = _add_conditions(lins, conditions)

--- a/parser_lineage_analyzer/analyzer.py
+++ b/parser_lineage_analyzer/analyzer.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Literal
 
 from ._analysis_executor import AnalysisExecutor
 from ._analysis_query import AnalysisQueryMixin
 from ._analysis_state import AnalyzerState
 from ._grok_patterns import GrokLibrary, bundled_library, load_library_from_paths
 from ._plugin_signatures import PluginSignatureRegistry
+from ._plugin_specs import DialectProfile, dialect_profile_for, normalize_dialect
 from .model import Lineage, SourceRef
 from .parser import parse_code_with_diagnostics
 
@@ -29,7 +31,8 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         parser_code: str,
         *,
         max_parser_bytes: int = MAX_PARSER_BYTES,
-        mutate_canonical_order: bool = False,
+        dialect: Literal["secops", "logstash"] = "secops",
+        mutate_canonical_order: bool | None = None,
         grok_patterns_dir: Sequence[Path | str] | None = None,
         plugin_signatures: PluginSignatureRegistry | None = None,
     ):
@@ -42,9 +45,11 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         token; analysis itself runs lazily on the first ``analyze``/``query``
         call. ``max_parser_bytes`` caps the UTF-8 size of ``parser_code`` and
         defaults to ``25_000_000``; pass a negative value (e.g. ``-1``) to
-        disable the limit. ``mutate_canonical_order`` opts into Logstash's
-        canonical per-block mutate execution order; the default of ``False``
-        preserves source order, which matches historical analyzer behavior.
+        disable the limit. ``dialect`` selects the parser compatibility
+        profile. ``"secops"`` is the default and preserves source-order mutate
+        semantics. ``"logstash"`` defaults to Logstash's canonical per-block
+        mutate execution order. ``mutate_canonical_order`` may be passed
+        explicitly to override either dialect default.
 
         ``grok_patterns_dir`` extends the bundled Logstash legacy grok pattern
         library with user-supplied pattern files. Each entry may be a file or
@@ -69,12 +74,17 @@ class ReverseParser(AnalysisQueryMixin, AnalysisExecutor):
         self.parser_code = parser_code
         self.ast, self.parse_diagnostics = parse_code_with_diagnostics(parser_code)
         self.state = AnalyzerState()
+        self.dialect = normalize_dialect(dialect)
+        self.dialect_profile: DialectProfile = dialect_profile_for(self.dialect)
+        self.state.dialect = self.dialect
         # Phase 4A: when set, the mutate dispatcher reorders operations to
         # match Logstash's hardcoded canonical order before iterating. This
-        # is opt-in because most real parsers exploit source-order semantics
-        # and changing the default would silently re-derive every existing
-        # mutate test.
-        self.state.mutate_canonical_order = mutate_canonical_order
+        # defaults by dialect but remains explicitly overridable.
+        self.state.mutate_canonical_order = (
+            self.dialect_profile.mutate_canonical_order_default
+            if mutate_canonical_order is None
+            else mutate_canonical_order
+        )
         # PR-B: grok pattern library. Bundled patterns are always loaded;
         # user-supplied directories merge on top with last-write-wins.
         # Stored on ``self`` (not ``self.state``) because the library is

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -496,6 +496,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.compact_json and args.compat_report:
         print("error: --compact-json and --compat-report are mutually exclusive", file=sys.stderr)
         return 2
+    if args.compat_report and args.strict:
+        print("error: --strict cannot be used with --compat-report", file=sys.stderr)
+        return 2
     # JSON output already includes the same fields ``--verbose`` would surface
     # in text mode (parser_locations, notes, structured_warnings,
     # diagnostics), so combining ``--verbose`` with ``--json``/``--compact-json``

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -52,6 +52,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--summary", action="store_true", help="Emit parser/analyzer coverage summary instead of querying one field."
     )
     parser.add_argument(
+        "--compat-report",
+        action="store_true",
+        help=(
+            "Emit a dialect-oriented compatibility report: unsupported "
+            "plugins, unsupported mutate operations, unknown config keys, "
+            "symbolic/dynamic features, failure-tag routes, and affected fields."
+        ),
+    )
+    parser.add_argument(
         "--compact-summary",
         action="store_true",
         help="Bound high-volume summary diagnostics and include counts by code. Implies --summary.",
@@ -71,6 +80,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Include full parser locations, notes, taints, and structured warning detail in text output.",
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--dialect",
+        choices=("secops", "logstash"),
+        default="secops",
+        help=(
+            "Parser compatibility profile. Defaults to secops. In logstash "
+            "mode, mutate{} blocks default to Logstash's canonical operation order."
+        ),
+    )
     parser.add_argument(
         "--max-parser-bytes",
         type=int,
@@ -96,6 +114,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Reorder operations within each mutate{} block into Logstash's "
             "canonical execution order before iterating. Default is source "
             "order; this flag opts into Logstash-fidelity semantics."
+        ),
+    )
+    parser.add_argument(
+        "--mutate-source-order",
+        action="store_true",
+        help=(
+            "Force source-order mutate{} execution. This overrides the "
+            "dialect default and is mutually exclusive with --mutate-canonical-order."
         ),
     )
     parser.add_argument(
@@ -423,14 +449,37 @@ def _augment_json_with_strict_failure(payload: str, failure: dict[str, object] |
     return json.dumps(data, indent=2, sort_keys=False)
 
 
+def _print_compat_report(report: Mapping[str, object]) -> None:
+    print(f"Dialect: {report.get('dialect', 'secops')}")
+    print(f"Mutate canonical order: {report.get('mutate_canonical_order', False)}")
+    totals = report.get("totals", {})
+    if isinstance(totals, Mapping):
+        print(f"Unsupported plugins: {totals.get('unsupported_plugins', 0)}")
+        print(f"Unsupported mutate operations: {totals.get('unsupported_mutate_operations', 0)}")
+        print(f"Unknown config keys: {totals.get('unknown_config_keys', 0)}")
+        print(f"Failure-tag routes: {totals.get('failure_tag_routes', 0)}")
+        print(f"Affected fields: {totals.get('affected_fields', 0)}")
+    dynamic_counts = report.get("dynamic_or_symbolic_warning_counts", {})
+    if isinstance(dynamic_counts, Mapping) and dynamic_counts:
+        print("Dynamic/symbolic warning counts:")
+        for code, count in sorted(dynamic_counts.items()):
+            print(f"  - {code}: {count}")
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(build_arg_parser(), argv)
     summary_requested = args.summary or args.compact_summary
-    if args.udm_field and (summary_requested or args.list):
-        print("error: udm_field cannot be used with --list, --summary, or --compact-summary", file=sys.stderr)
+    if args.udm_field and (summary_requested or args.list or args.compat_report):
+        print(
+            "error: udm_field cannot be used with --list, --summary, --compact-summary, or --compat-report",
+            file=sys.stderr,
+        )
         return 2
-    if args.list and summary_requested:
-        print("error: --list and --summary/--compact-summary are mutually exclusive", file=sys.stderr)
+    if args.list and (summary_requested or args.compat_report):
+        print("error: --list and --summary/--compact-summary/--compat-report are mutually exclusive", file=sys.stderr)
+        return 2
+    if args.compat_report and summary_requested:
+        print("error: --compat-report and --summary/--compact-summary are mutually exclusive", file=sys.stderr)
         return 2
     if args.json and args.compact_json:
         print("error: --json and --compact-json are mutually exclusive", file=sys.stderr)
@@ -444,14 +493,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.compact_json and args.compact_summary:
         print("error: --compact-json and --compact-summary are mutually exclusive", file=sys.stderr)
         return 2
+    if args.compact_json and args.compat_report:
+        print("error: --compact-json and --compat-report are mutually exclusive", file=sys.stderr)
+        return 2
     # JSON output already includes the same fields ``--verbose`` would surface
     # in text mode (parser_locations, notes, structured_warnings,
     # diagnostics), so combining ``--verbose`` with ``--json``/``--compact-json``
     # is a no-op rather than an error. Only warn for the modes where
     # ``--verbose`` is genuinely silent (--list, --summary, --compact-summary).
-    if args.verbose and (args.list or args.summary or args.compact_summary):
+    if args.verbose and (args.list or args.summary or args.compact_summary or args.compat_report):
         print(
-            "warning: --verbose is ignored with --list, --summary, or --compact-summary",
+            "warning: --verbose is ignored with --list, --summary, --compact-summary, or --compat-report",
             file=sys.stderr,
         )
     if args.udm_field is not None:
@@ -460,6 +512,9 @@ def main(argv: list[str] | None = None) -> int:
             print("error: udm_field cannot be empty", file=sys.stderr)
             return 2
         args.udm_field = stripped_udm
+    if args.mutate_canonical_order and args.mutate_source_order:
+        print("error: --mutate-canonical-order and --mutate-source-order are mutually exclusive", file=sys.stderr)
+        return 2
     try:
         code = _read_parser(args.parser_file, args.max_parser_bytes)
     except FileNotFoundError:
@@ -509,16 +564,30 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     try:
+        mutate_canonical_order = None
+        if args.mutate_canonical_order:
+            mutate_canonical_order = True
+        elif args.mutate_source_order:
+            mutate_canonical_order = False
         rp = ReverseParser(
             code,
             max_parser_bytes=args.max_parser_bytes,
-            mutate_canonical_order=args.mutate_canonical_order,
+            dialect=args.dialect,
+            mutate_canonical_order=mutate_canonical_order,
             grok_patterns_dir=args.grok_patterns_dir or None,
             plugin_signatures=plugin_signatures,
         )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    if args.compat_report:
+        report = rp.compat_report(compact=False)
+        _warn_if_parse_recovery(rp.analyze().structured_warnings)
+        if args.json:
+            print(json.dumps(report, indent=2))
+        else:
+            _print_compat_report(report)
+        return 0
     if summary_requested:
         summary = rp.analysis_summary(compact=args.compact_summary)
         _warn_if_parse_recovery(_summary_sequence(summary, "structured_warnings"))
@@ -629,7 +698,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if not args.udm_field:
         print(
-            "error: udm_field is required unless --list, --summary, or --compact-summary is used",
+            "error: udm_field is required unless --list, --summary, --compact-summary, or --compat-report is used",
             file=sys.stderr,
         )
         return 2

--- a/parser_lineage_analyzer/plugin_signatures/common.toml
+++ b/parser_lineage_analyzer/plugin_signatures/common.toml
@@ -1,0 +1,48 @@
+[cidr_lookup]
+semantic_class = "enricher"
+source_keys = ["address", "source", "network"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"
+
+[enrich_geoip]
+semantic_class = "enricher"
+source_keys = ["ip", "source"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"
+
+[http_filter]
+semantic_class = "enricher"
+source_keys = ["url"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"
+
+[jdbc_lookup]
+semantic_class = "enricher"
+source_keys = ["statement", "query"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"
+
+[rest_filter]
+semantic_class = "enricher"
+source_keys = ["url"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"
+
+[throttle]
+semantic_class = "passthrough"
+source_keys = ["key", "before_count", "after_count"]
+dest_keys = []
+lineage_status = "derived"
+taint_hint = "none"
+
+[threat_lookup]
+semantic_class = "enricher"
+source_keys = ["source", "indicator", "query"]
+dest_keys = ["target"]
+lineage_status = "dynamic"
+taint_hint = "dynamic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ parser_lineage_analyzer = [
   "grok_patterns/*",
   "grok_patterns/LICENSE",
   "grok_patterns/NOTICE",
+  "plugin_signatures/*.toml",
 ]
 
 [tool.setuptools.exclude-package-data]

--- a/scripts/compat_audit_corpus.py
+++ b/scripts/compat_audit_corpus.py
@@ -47,7 +47,7 @@ def audit_corpus(
         for path in parser_files:
             rel_path = path.relative_to(root).as_posix()
             try:
-                code = path.read_text(encoding="utf-8")
+                code = path.read_text(encoding="utf-8-sig")
                 report = ReverseParser(code, dialect=dialect, plugin_signatures=plugin_signatures).compat_report(
                     compact=True
                 )
@@ -173,6 +173,9 @@ def regression_messages(current: dict[str, Any], baseline: dict[str, Any]) -> li
     baseline_totals = baseline.get("totals_by_dialect", {})
     if not isinstance(current_totals, dict) or not isinstance(baseline_totals, dict):
         return ["baseline/current audit shape is invalid"]
+    for dialect in sorted(current_totals):
+        if isinstance(dialect, str) and dialect not in baseline_totals:
+            messages.append(f"{dialect}: missing baseline dialect")
     for dialect, baseline_payload in baseline_totals.items():
         if not isinstance(dialect, str) or not isinstance(baseline_payload, dict):
             continue

--- a/scripts/compat_audit_corpus.py
+++ b/scripts/compat_audit_corpus.py
@@ -1,0 +1,247 @@
+"""Batch compatibility audit for parser corpus fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from parser_lineage_analyzer import ReverseParser
+from parser_lineage_analyzer._plugin_signatures import PluginSignatureRegistry, load_bundled_registry
+
+DEFAULT_ROOT = Path("tests/fixtures/test_corpus")
+DEFAULT_OUT_DIR = Path("build/compat-audit")
+DEFAULT_DIALECTS = ("secops", "logstash")
+REGRESSION_TOTAL_KEYS = (
+    "unsupported_plugins",
+    "unsupported_mutate_operations",
+    "unknown_config_keys",
+    "dynamic_or_symbolic_warnings",
+)
+
+
+def iter_parser_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("*.cbn") if path.is_file())
+
+
+def audit_corpus(
+    root: Path, dialects: list[str], plugin_signatures: PluginSignatureRegistry | None = None
+) -> dict[str, Any]:
+    root = root.resolve()
+    parser_files = iter_parser_files(root)
+    reports_by_dialect: dict[str, list[dict[str, Any]]] = {}
+    totals_by_dialect: dict[str, dict[str, Any]] = {}
+
+    for dialect in dialects:
+        reports: list[dict[str, Any]] = []
+        unsupported_plugins: Counter[str] = Counter()
+        unsupported_mutate_ops: Counter[str] = Counter()
+        unknown_config_keys: Counter[str] = Counter()
+        warning_counts: Counter[str] = Counter()
+        affected_fields: Counter[str] = Counter()
+        totals: Counter[str] = Counter()
+
+        for path in parser_files:
+            rel_path = path.relative_to(root).as_posix()
+            try:
+                code = path.read_text(encoding="utf-8")
+                report = ReverseParser(code, dialect=dialect, plugin_signatures=plugin_signatures).compat_report(
+                    compact=True
+                )
+            except Exception as exc:  # pragma: no cover - defensive path for malformed external corpora
+                report = {
+                    "dialect": dialect,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "totals": {
+                        "unsupported_plugins": 0,
+                        "unsupported_mutate_operations": 0,
+                        "unknown_config_keys": 0,
+                        "failure_tag_routes": 0,
+                        "affected_fields": 0,
+                        "dynamic_or_symbolic_warnings": 0,
+                    },
+                    "warning_counts": {"audit_error": 1},
+                    "unsupported_plugin_counts": {},
+                    "unsupported_mutate_operation_counts": {},
+                    "unknown_config_key_counts": {},
+                    "affected_field_counts": {},
+                }
+            reports.append({"path": rel_path, "report": report})
+            report_totals = report.get("totals", {})
+            if isinstance(report_totals, dict):
+                for key, value in report_totals.items():
+                    if isinstance(value, int):
+                        totals[key] += value
+            unsupported_plugins.update(_counter_from_report(report, "unsupported_plugin_counts"))
+            unsupported_mutate_ops.update(_counter_from_report(report, "unsupported_mutate_operation_counts"))
+            unknown_config_keys.update(_counter_from_report(report, "unknown_config_key_counts"))
+            warning_counts.update(_counter_from_report(report, "warning_counts"))
+            affected_fields.update(_counter_from_report(report, "affected_field_counts"))
+
+        reports_by_dialect[dialect] = reports
+        totals_by_dialect[dialect] = {
+            "parser_count": len(parser_files),
+            "totals": dict(sorted(totals.items())),
+            "unsupported_plugin_counts": _top_counts(unsupported_plugins),
+            "unsupported_mutate_operation_counts": _top_counts(unsupported_mutate_ops),
+            "unknown_config_key_counts": _top_counts(unknown_config_keys),
+            "warning_counts": _top_counts(warning_counts),
+            "top_affected_fields": _top_counts(affected_fields),
+        }
+
+    return {
+        "root": root.as_posix(),
+        "dialects": dialects,
+        "plugin_signatures": {
+            "enabled": plugin_signatures is not None,
+            "count": len(plugin_signatures) if plugin_signatures is not None else 0,
+        },
+        "parser_count": len(parser_files),
+        "totals_by_dialect": totals_by_dialect,
+        "reports_by_dialect": reports_by_dialect,
+    }
+
+
+def _counter_from_report(report: dict[str, Any], key: str) -> Counter[str]:
+    raw = report.get(key, {})
+    if not isinstance(raw, dict):
+        return Counter()
+    out: Counter[str] = Counter()
+    for item, count in raw.items():
+        if isinstance(count, int):
+            out[str(item)] += count
+    return out
+
+
+def _top_counts(counter: Counter[str], limit: int = 25) -> dict[str, int]:
+    return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit])
+
+
+def render_markdown(audit: dict[str, Any]) -> str:
+    lines = [
+        "# Parser Compatibility Audit",
+        "",
+        f"- Root: `{audit['root']}`",
+        f"- Parsers: {audit['parser_count']}",
+        f"- Dialects: {', '.join(audit['dialects'])}",
+        f"- Plugin signatures: {audit['plugin_signatures']['count'] if audit['plugin_signatures']['enabled'] else 0}",
+        "",
+    ]
+    totals_by_dialect = audit["totals_by_dialect"]
+    for dialect in audit["dialects"]:
+        dialect_totals = totals_by_dialect[dialect]
+        totals = dialect_totals["totals"]
+        lines.extend(
+            [
+                f"## {dialect}",
+                "",
+                "| Metric | Count |",
+                "| --- | ---: |",
+            ]
+        )
+        for key in sorted(totals):
+            lines.append(f"| {key} | {totals[key]} |")
+        lines.append("")
+        for heading, key in (
+            ("Unsupported Plugins", "unsupported_plugin_counts"),
+            ("Unsupported Mutate Ops", "unsupported_mutate_operation_counts"),
+            ("Unknown Config Keys", "unknown_config_key_counts"),
+            ("Warning Counts", "warning_counts"),
+            ("Top Affected Fields", "top_affected_fields"),
+        ):
+            lines.extend(_markdown_counts(heading, dialect_totals[key]))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _markdown_counts(heading: str, counts: dict[str, int]) -> list[str]:
+    lines = [f"### {heading}", ""]
+    if not counts:
+        return [*lines, "_None_", ""]
+    lines.extend(["| Name | Count |", "| --- | ---: |"])
+    for name, count in counts.items():
+        lines.append(f"| `{name}` | {count} |")
+    lines.append("")
+    return lines
+
+
+def regression_messages(current: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    current_totals = current.get("totals_by_dialect", {})
+    baseline_totals = baseline.get("totals_by_dialect", {})
+    if not isinstance(current_totals, dict) or not isinstance(baseline_totals, dict):
+        return ["baseline/current audit shape is invalid"]
+    for dialect, baseline_payload in baseline_totals.items():
+        if not isinstance(dialect, str) or not isinstance(baseline_payload, dict):
+            continue
+        current_payload = current_totals.get(dialect)
+        if not isinstance(current_payload, dict):
+            messages.append(f"{dialect}: missing current dialect")
+            continue
+        baseline_counts = baseline_payload.get("totals", {})
+        current_counts = current_payload.get("totals", {})
+        if not isinstance(baseline_counts, dict) or not isinstance(current_counts, dict):
+            continue
+        for key in REGRESSION_TOTAL_KEYS:
+            old = baseline_counts.get(key, 0)
+            new = current_counts.get(key, 0)
+            if isinstance(old, int) and isinstance(new, int) and new > old:
+                messages.append(f"{dialect}: {key} regressed from {old} to {new}")
+    return messages
+
+
+def write_outputs(audit: dict[str, Any], json_out: Path, md_out: Path) -> None:
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    md_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_out.write_text(render_markdown(audit), encoding="utf-8")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help="Corpus root containing .cbn files.")
+    parser.add_argument(
+        "--dialect",
+        action="append",
+        choices=DEFAULT_DIALECTS,
+        help="Dialect to audit. Repeat to compare multiple dialects. Defaults to secops and logstash.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR, help="Default output directory.")
+    parser.add_argument("--json-out", type=Path, help="JSON artifact path.")
+    parser.add_argument("--md-out", type=Path, help="Markdown artifact path.")
+    parser.add_argument(
+        "--bundled-signatures",
+        action="store_true",
+        help="Load bundled conservative plugin signatures during the audit.",
+    )
+    parser.add_argument("--fail-on-regression", type=Path, help="Baseline JSON artifact to compare against.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    dialects = list(dict.fromkeys(args.dialect or list(DEFAULT_DIALECTS)))
+    json_out = args.json_out or (args.out_dir / "compat-audit.json")
+    md_out = args.md_out or (args.out_dir / "compat-audit.md")
+
+    plugin_signatures = load_bundled_registry() if args.bundled_signatures else None
+    audit = audit_corpus(args.root, dialects, plugin_signatures=plugin_signatures)
+    write_outputs(audit, json_out, md_out)
+
+    if args.fail_on_regression:
+        baseline = json.loads(args.fail_on_regression.read_text(encoding="utf-8"))
+        messages = regression_messages(audit, baseline)
+        if messages:
+            for message in messages:
+                print(message, file=sys.stderr)
+            return 1
+
+    print(f"Wrote {json_out}")
+    print(f"Wrote {md_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime_fixture_check.py
+++ b/scripts/runtime_fixture_check.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from parser_lineage_analyzer import ReverseParser
+from parser_lineage_analyzer._plugin_specs import normalize_dialect
 
 DEFAULT_ROOT = Path("tests/fixtures/runtime")
 
@@ -35,7 +36,8 @@ def check_fixture(fixture_dir: Path) -> dict[str, Any]:
     expected_path = fixture_dir / "expected.json"
     expected = json.loads(expected_path.read_text(encoding="utf-8"))
     code = parser_path.read_text(encoding="utf-8")
-    parser = ReverseParser(code)
+    dialect = normalize_dialect(str(expected.get("dialect", "secops")))
+    parser = ReverseParser(code, dialect=dialect)
     state = parser.analyze()
 
     expected_fields = _string_list(expected, "touched_fields")
@@ -58,6 +60,7 @@ def check_fixture(fixture_dir: Path) -> dict[str, Any]:
         "fixture": fixture_dir.name,
         "parser": parser_path.as_posix(),
         "input": input_path.as_posix() if input_path.exists() else None,
+        "dialect": dialect,
         "passed": not failed,
         "expected": {
             "touched_fields": expected_fields,

--- a/scripts/runtime_fixture_check.py
+++ b/scripts/runtime_fixture_check.py
@@ -1,0 +1,124 @@
+"""Validate static lineage against runtime-observation fixtures.
+
+Fixture layout:
+
+    fixture_name/
+      parser.cbn
+      input.json
+      expected.json
+
+``input.json`` is retained as the observed runtime sample, but this script does
+not execute parsers. It checks that static analysis covers the fields, tags, and
+output anchors listed in ``expected.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from parser_lineage_analyzer import ReverseParser
+
+DEFAULT_ROOT = Path("tests/fixtures/runtime")
+
+
+def discover_fixtures(root: Path) -> list[Path]:
+    return sorted(path.parent for path in root.rglob("expected.json") if (path.parent / "parser.cbn").is_file())
+
+
+def check_fixture(fixture_dir: Path) -> dict[str, Any]:
+    parser_path = fixture_dir / "parser.cbn"
+    input_path = fixture_dir / "input.json"
+    expected_path = fixture_dir / "expected.json"
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    code = parser_path.read_text(encoding="utf-8")
+    parser = ReverseParser(code)
+    state = parser.analyze()
+
+    expected_fields = _string_list(expected, "touched_fields")
+    expected_tags = _string_list(expected, "tags")
+    expected_anchors = _string_list(expected, "output_anchors")
+
+    missing_fields = [field for field in expected_fields if not _field_is_covered(parser, field)]
+    possible_tags = set(state.tag_state.possibly) | set(state.tag_state.definitely)
+    missing_tags = [tag for tag in expected_tags if tag not in possible_tags]
+    anchors = {anchor.anchor for anchor in state.output_anchors}
+    missing_anchors = [anchor for anchor in expected_anchors if anchor not in anchors]
+
+    failures = {
+        "missing_fields": missing_fields,
+        "missing_tags": missing_tags,
+        "missing_output_anchors": missing_anchors,
+    }
+    failed = any(failures.values())
+    return {
+        "fixture": fixture_dir.name,
+        "parser": parser_path.as_posix(),
+        "input": input_path.as_posix() if input_path.exists() else None,
+        "passed": not failed,
+        "expected": {
+            "touched_fields": expected_fields,
+            "tags": expected_tags,
+            "output_anchors": expected_anchors,
+        },
+        "failures": failures,
+    }
+
+
+def check_runtime_fixtures(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    results = [check_fixture(fixture_dir) for fixture_dir in discover_fixtures(root)]
+    failed = [result for result in results if not result["passed"]]
+    return {
+        "root": root.as_posix(),
+        "fixture_count": len(results),
+        "passed": len(results) - len(failed),
+        "failed": len(failed),
+        "results": results,
+    }
+
+
+def _string_list(expected: dict[str, Any], key: str) -> list[str]:
+    value = expected.get(key, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{key} must be a list")
+    return [str(item) for item in value]
+
+
+def _field_is_covered(parser: ReverseParser, field: str) -> bool:
+    state = parser.analyze()
+    if field in state.tokens:
+        return True
+    return bool(parser.query(field, compact=True).mappings)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help="Runtime fixture root.")
+    parser.add_argument("--json-out", type=Path, help="Optional JSON result path.")
+    parser.add_argument("--no-fail", action="store_true", help="Return 0 even when fixtures mismatch.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    report = check_runtime_fixtures(args.root)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    if report["failed"] and not args.no_fail:
+        for result in report["results"]:
+            if not result["passed"]:
+                print(f"{result['fixture']}: runtime fixture mismatch", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime_fixture_check.py
+++ b/scripts/runtime_fixture_check.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from parser_lineage_analyzer import ReverseParser
+from parser_lineage_analyzer._analysis_state import AnalyzerState
 from parser_lineage_analyzer._plugin_specs import normalize_dialect
 
 DEFAULT_ROOT = Path("tests/fixtures/runtime")
@@ -44,7 +45,7 @@ def check_fixture(fixture_dir: Path) -> dict[str, Any]:
     expected_tags = _string_list(expected, "tags")
     expected_anchors = _string_list(expected, "output_anchors")
 
-    missing_fields = [field for field in expected_fields if not _field_is_covered(parser, field)]
+    missing_fields = [field for field in expected_fields if not _field_is_covered(parser, state, field)]
     possible_tags = set(state.tag_state.possibly) | set(state.tag_state.definitely)
     missing_tags = [tag for tag in expected_tags if tag not in possible_tags]
     anchors = {anchor.anchor for anchor in state.output_anchors}
@@ -91,8 +92,7 @@ def _string_list(expected: dict[str, Any], key: str) -> list[str]:
     return [str(item) for item in value]
 
 
-def _field_is_covered(parser: ReverseParser, field: str) -> bool:
-    state = parser.analyze()
+def _field_is_covered(parser: ReverseParser, state: AnalyzerState, field: str) -> bool:
     if field in state.tokens:
         return True
     return bool(parser.query(field, compact=True).mappings)

--- a/tests/fixtures/runtime/basic_routing/expected.json
+++ b/tests/fixtures/runtime/basic_routing/expected.json
@@ -1,0 +1,5 @@
+{
+  "touched_fields": ["event.idm.read_only_udm.target.ip"],
+  "tags": ["routed_runtime_fixture"],
+  "output_anchors": ["event"]
+}

--- a/tests/fixtures/runtime/basic_routing/input.json
+++ b/tests/fixtures/runtime/basic_routing/input.json
@@ -1,0 +1,3 @@
+{
+  "message": "fixture"
+}

--- a/tests/fixtures/runtime/basic_routing/parser.cbn
+++ b/tests/fixtures/runtime/basic_routing/parser.cbn
@@ -1,0 +1,9 @@
+filter {
+  mutate {
+    replace => {
+      "event.idm.read_only_udm.target.ip" => "1.2.3.4"
+    }
+    add_tag => ["routed_runtime_fixture"]
+  }
+  mutate { merge => { "@output" => "event" } }
+}

--- a/tests/fixtures/test_corpus/baseline/test_baseline_grok_chain_dependency.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_grok_chain_dependency.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_have_warning_codes": ["unknown_config_key"],
-  "must_not_have_warning_codes": ["malformed_config", "parse_recovery"]
+  "must_not_have_warning_codes": ["malformed_config", "parse_recovery", "unknown_config_key"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_json_fallback_to_kv.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_json_fallback_to_kv.expected.json
@@ -1,4 +1,4 @@
 {
-  "must_have_warning_codes": ["unknown_config_key", "unresolved_extractor_source"],
-  "must_not_have_warning_codes": ["malformed_config", "parse_recovery"]
+  "must_have_warning_codes": ["conditional_tag_check", "unresolved_extractor_source"],
+  "must_not_have_warning_codes": ["malformed_config", "parse_recovery", "unknown_config_key"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_kv_complex.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_kv_complex.expected.json
@@ -1,4 +1,4 @@
 {
-  "must_have_warning_codes": ["config_validation", "unknown_config_key"],
-  "must_not_have_warning_codes": ["malformed_config", "parse_recovery"]
+  "must_have_warning_codes": ["config_validation"],
+  "must_not_have_warning_codes": ["malformed_config", "parse_recovery", "unknown_config_key"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_mutate_array_functions.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_mutate_array_functions.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_have_warning_codes": ["unsupported_mutate_operation"],
-  "must_have_unsupported": ["strip"]
+  "must_not_have_warning_codes": ["unsupported_mutate_operation"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_xml_xpath_extraction.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_xml_xpath_extraction.expected.json
@@ -1,4 +1,4 @@
 {
-  "must_have_warning_codes": ["unknown_config_key", "unresolved_extractor_source"],
-  "must_not_have_warning_codes": ["malformed_config", "parse_recovery"]
+  "must_have_warning_codes": ["unresolved_extractor_source"],
+  "must_not_have_warning_codes": ["malformed_config", "parse_recovery", "unknown_config_key"]
 }

--- a/tests/fixtures/test_corpus/expected/test_cascading_datetime_fallbacks.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_cascading_datetime_fallbacks.expected.json
@@ -1,4 +1,5 @@
 {
-  "must_have_warning_codes": ["unknown_config_key", "unreachable_branch"],
+  "must_have_warning_codes": ["conditional_tag_check"],
+  "must_not_have_warning_codes": ["unknown_config_key"],
   "must_resolve_fields": ["tags", "@timestamp"]
 }

--- a/tests/fixtures/test_corpus/expected/test_complex_json_xml_hybrid_payload.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_complex_json_xml_hybrid_payload.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_have_warning_codes": ["unknown_config_key"],
-  "must_not_have_warning_codes": ["malformed_config"]
+  "must_not_have_warning_codes": ["malformed_config", "unknown_config_key"]
 }

--- a/tests/fixtures/test_corpus/expected/test_external_lookup_verification.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_external_lookup_verification.expected.json
@@ -1,4 +1,5 @@
 {
+  "dialect": "logstash",
   "must_resolve_fields": [
     "es_results",
     "has_es_results"

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -91,6 +91,13 @@ def test_cli_compat_report_json(tmp_path, capsys):
     assert payload["totals"]["failure_tag_routes"] >= 1
 
 
+def test_cli_rejects_strict_with_compat_report(tmp_path, capsys):
+    parser_file = _write_parser(tmp_path)
+
+    assert main([str(parser_file), "--compat-report", "--strict"]) == 2
+    assert "--strict cannot be used with --compat-report" in capsys.readouterr().err
+
+
 def test_cli_stdin_query_json_success(monkeypatch, capsys):
     monkeypatch.setattr(sys, "stdin", io.StringIO(SIMPLE_CODE))
     assert main(["-", "target.ip", "--json"]) == 0

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -46,6 +46,54 @@ def test_cli_accepts_flags_between_parser_file_and_udm_field(tmp_path, capsys):
     assert payload["status"] == "exact"
 
 
+def test_cli_dialect_and_mutate_order_overrides(tmp_path, capsys):
+    code = r"""
+    filter {
+      mutate {
+        replace => { "source" => "value" }
+        rename => { "source" => "event.idm.read_only_udm.target.hostname" }
+      }
+      mutate { merge => { "@output" => "event" } }
+    }
+    """
+    parser_file = _write_parser(tmp_path, code)
+
+    assert main([str(parser_file), "target.hostname", "--json", "--dialect", "logstash"]) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "unresolved"
+
+    assert (
+        main([str(parser_file), "target.hostname", "--json", "--dialect", "logstash", "--mutate-source-order"])
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["status"] == "derived"
+
+
+def test_cli_rejects_conflicting_mutate_order_flags(tmp_path, capsys):
+    parser_file = _write_parser(tmp_path)
+
+    assert main([str(parser_file), "--summary", "--mutate-canonical-order", "--mutate-source-order"]) == 2
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+def test_cli_compat_report_json(tmp_path, capsys):
+    parser_file = _write_parser(
+        tmp_path,
+        r"""
+        filter {
+          grok { match => { "message" => "%{IP:src_ip}" } tag_on_failure => ["custom_fail"] }
+          totally_custom { target => "event.idm.read_only_udm.target.ip" }
+        }
+        """,
+    )
+
+    assert main([str(parser_file), "--compat-report", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["dialect"] == "secops"
+    assert payload["totals"]["unsupported_plugins"] == 1
+    assert payload["totals"]["failure_tag_routes"] >= 1
+
+
 def test_cli_stdin_query_json_success(monkeypatch, capsys):
     monkeypatch.setattr(sys, "stdin", io.StringIO(SIMPLE_CODE))
     assert main(["-", "target.ip", "--json"]) == 0

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -61,10 +61,7 @@ def test_cli_dialect_and_mutate_order_overrides(tmp_path, capsys):
     assert main([str(parser_file), "target.hostname", "--json", "--dialect", "logstash"]) == 0
     assert json.loads(capsys.readouterr().out)["status"] == "unresolved"
 
-    assert (
-        main([str(parser_file), "target.hostname", "--json", "--dialect", "logstash", "--mutate-source-order"])
-        == 0
-    )
+    assert main([str(parser_file), "target.hostname", "--json", "--dialect", "logstash", "--mutate-source-order"]) == 0
     assert json.loads(capsys.readouterr().out)["status"] == "derived"
 
 

--- a/tests/test_compat_audit_corpus.py
+++ b/tests/test_compat_audit_corpus.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from parser_lineage_analyzer._plugin_signatures import load_bundled_registry
+from scripts import compat_audit_corpus
+
+
+def test_compat_audit_writes_json_and_markdown(tmp_path):
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (root / "a.cbn").write_text(
+        'filter { grok { match => { "message" => "%{IP:src_ip}" } } }\n',
+        encoding="utf-8",
+    )
+    (root / "b.cbn").write_text(
+        'filter { custom_lookup { target => "event.idm.read_only_udm.target.ip" } }\n',
+        encoding="utf-8",
+    )
+
+    audit = compat_audit_corpus.audit_corpus(root, ["secops"])
+    json_out = tmp_path / "out" / "compat.json"
+    md_out = tmp_path / "out" / "compat.md"
+    compat_audit_corpus.write_outputs(audit, json_out, md_out)
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = md_out.read_text(encoding="utf-8")
+
+    assert payload["parser_count"] == 2
+    assert [entry["path"] for entry in payload["reports_by_dialect"]["secops"]] == ["a.cbn", "b.cbn"]
+    assert payload["totals_by_dialect"]["secops"]["totals"]["unsupported_plugins"] == 1
+    assert payload["totals_by_dialect"]["secops"]["unsupported_plugin_counts"] == {"custom_lookup": 1}
+    assert "# Parser Compatibility Audit" in markdown
+    assert "Unsupported Plugins" in markdown
+
+
+def test_compat_audit_main_honors_dialects_and_regression_baseline(tmp_path, capsys):
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (root / "a.cbn").write_text('filter { custom_lookup { target => "x" } }\n', encoding="utf-8")
+
+    current_json = tmp_path / "audit.json"
+    current_md = tmp_path / "audit.md"
+    rc = compat_audit_corpus.main(
+        [
+            "--root",
+            str(root),
+            "--dialect",
+            "secops",
+            "--json-out",
+            str(current_json),
+            "--md-out",
+            str(current_md),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(current_json.read_text(encoding="utf-8"))
+    assert payload["dialects"] == ["secops"]
+
+    baseline = payload.copy()
+    baseline["totals_by_dialect"] = {
+        "secops": {
+            **payload["totals_by_dialect"]["secops"],
+            "totals": {**payload["totals_by_dialect"]["secops"]["totals"], "unsupported_plugins": 0},
+        }
+    }
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    rc = compat_audit_corpus.main(
+        [
+            "--root",
+            str(root),
+            "--dialect",
+            "secops",
+            "--json-out",
+            str(tmp_path / "audit2.json"),
+            "--md-out",
+            str(tmp_path / "audit2.md"),
+            "--fail-on-regression",
+            str(baseline_path),
+        ]
+    )
+    assert rc == 1
+    assert "unsupported_plugins regressed from 0 to 1" in capsys.readouterr().err
+
+
+def test_compat_audit_can_use_bundled_signatures_to_reduce_unsupported_counts(tmp_path):
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (root / "a.cbn").write_text('filter { throttle { key => "%{message}" } }\n', encoding="utf-8")
+
+    without_signatures = compat_audit_corpus.audit_corpus(root, ["secops"])
+    with_signatures = compat_audit_corpus.audit_corpus(root, ["secops"], plugin_signatures=load_bundled_registry())
+
+    assert without_signatures["totals_by_dialect"]["secops"]["totals"]["unsupported_plugins"] == 1
+    assert with_signatures["totals_by_dialect"]["secops"]["totals"].get("unsupported_plugins", 0) == 0
+    assert with_signatures["plugin_signatures"]["enabled"] is True

--- a/tests/test_compat_audit_corpus.py
+++ b/tests/test_compat_audit_corpus.py
@@ -10,7 +10,7 @@ def test_compat_audit_writes_json_and_markdown(tmp_path):
     root = tmp_path / "corpus"
     root.mkdir()
     (root / "a.cbn").write_text(
-        'filter { grok { match => { "message" => "%{IP:src_ip}" } } }\n',
+        '\ufefffilter { grok { match => { "message" => "%{IP:src_ip}" } } }\n',
         encoding="utf-8",
     )
     (root / "b.cbn").write_text(
@@ -32,6 +32,13 @@ def test_compat_audit_writes_json_and_markdown(tmp_path):
     assert payload["totals_by_dialect"]["secops"]["unsupported_plugin_counts"] == {"custom_lookup": 1}
     assert "# Parser Compatibility Audit" in markdown
     assert "Unsupported Plugins" in markdown
+
+
+def test_regression_messages_reports_current_only_dialects():
+    current = {"totals_by_dialect": {"secops": {"totals": {}}, "logstash": {"totals": {}}}}
+    baseline = {"totals_by_dialect": {"secops": {"totals": {}}}}
+
+    assert compat_audit_corpus.regression_messages(current, baseline) == ["logstash: missing baseline dialect"]
 
 
 def test_compat_audit_main_honors_dialects_and_regression_baseline(tmp_path, capsys):

--- a/tests/test_corpus_baseline.py
+++ b/tests/test_corpus_baseline.py
@@ -21,7 +21,8 @@ Sidecar schema (all keys optional; missing keys mean "don't check"):
   "must_have_warning_codes": ["dynamic_destination", "drop"],
   "must_resolve_fields":     ["target.ip", "principal.hostname"],
   "must_have_unsupported":   ["ruby"],
-  "must_not_have_warning_codes": ["malformed_config"]
+  "must_not_have_warning_codes": ["malformed_config"],
+  "dialect": "logstash"
 }
 ```
 
@@ -82,10 +83,11 @@ SIDECAR_KEYS = (
     "must_not_have_warning_codes",
     "must_resolve_fields",
     "must_have_unsupported",
+    "dialect",
 )
 
 
-def _sidecar_for(fixture_path: Path) -> dict[str, list[str]] | None:
+def _sidecar_for(fixture_path: Path) -> dict[str, object] | None:
     sidecar = fixture_path.with_suffix(".expected.json")
     if not sidecar.exists():
         return None
@@ -98,21 +100,21 @@ def _sidecar_for(fixture_path: Path) -> dict[str, list[str]] | None:
     return data
 
 
-def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, list[str]]) -> None:
+def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, object]) -> None:
     summary = parser.analysis_summary()
     warning_codes = {expect_str(expect_mapping(w)["code"]) for w in expect_mapping_list(summary["structured_warnings"])}
     unsupported_blobs = " | ".join(expect_str_list(summary["unsupported"]))
 
-    for code in sidecar.get("must_have_warning_codes", []):
+    for code in expect_str_list(sidecar.get("must_have_warning_codes", [])):
         assert code in warning_codes, (
             f"{fixture_id}: expected warning code {code!r} not emitted; got {sorted(warning_codes)}"
         )
-    for code in sidecar.get("must_not_have_warning_codes", []):
+    for code in expect_str_list(sidecar.get("must_not_have_warning_codes", [])):
         assert code not in warning_codes, f"{fixture_id}: warning code {code!r} should NOT be emitted but was"
-    for field in sidecar.get("must_resolve_fields", []):
+    for field in expect_str_list(sidecar.get("must_resolve_fields", [])):
         result = parser.query(field)
         assert result.mappings, f"{fixture_id}: query({field!r}) returned no mappings"
-    for plugin in sidecar.get("must_have_unsupported", []):
+    for plugin in expect_str_list(sidecar.get("must_have_unsupported", [])):
         assert plugin in unsupported_blobs, (
             f"{fixture_id}: expected {plugin!r} in unsupported list; got {summary['unsupported']!r}"
         )
@@ -121,8 +123,10 @@ def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, li
 @pytest.mark.parametrize("fixture_path", _FIXTURES, ids=[_fixture_id(p) for p in _FIXTURES])
 def test_corpus_fixture_analyzes_cleanly(fixture_path: Path) -> None:
     src = fixture_path.read_text(encoding="utf-8")
+    sidecar = _sidecar_for(fixture_path)
+    dialect = expect_str(sidecar.get("dialect", "secops")) if sidecar is not None else "secops"
     start = time.perf_counter()
-    parser = ReverseParser(src)
+    parser = ReverseParser(src, dialect=dialect)
     parser.analyze()
     elapsed = time.perf_counter() - start
     assert elapsed < PER_FIXTURE_BUDGET_SECONDS, (
@@ -142,7 +146,6 @@ def test_corpus_fixture_analyzes_cleanly(fixture_path: Path) -> None:
             + "\nIf this is intentional, add a malformed-input phrase to the fixture header."
         )
 
-    sidecar = _sidecar_for(fixture_path)
     if sidecar is not None:
         _check_sidecar(parser, _fixture_id(fixture_path), sidecar)
 

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -247,6 +247,7 @@ def test_mutate_registry_contains_supported_operations():
         "convert": "_exec_convert_mutate_op",
         "lowercase": "_exec_case_mutate_op",
         "uppercase": "_exec_case_mutate_op",
+        "strip": "_exec_case_mutate_op",
         "gsub": "_exec_gsub_mutate_op",
         "split": "_exec_split_mutate_op",
         "join": "_exec_join_mutate_op",

--- a/tests/test_plugin_behavior.py
+++ b/tests/test_plugin_behavior.py
@@ -559,7 +559,7 @@ def test_default_failure_tags_are_possible_not_definite():
           }
         }
         """,
-        dialect="logstash"
+        dialect="logstash",
     )
     state = parser.analyze()
     codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
@@ -583,7 +583,7 @@ def test_empty_failure_tags_suppress_default_failure_route():
           }
         }
         """,
-        dialect="logstash"
+        dialect="logstash",
     )
     state = parser.analyze()
     codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
@@ -684,7 +684,7 @@ def test_translate_regex_and_dictionary_path_stay_dynamic_with_warning():
 
 def test_translate_projects_json_object_dictionary_values():
     parser = ReverseParser(
-        r'''
+        r"""
         filter {
           translate {
             field => "error_code"
@@ -695,7 +695,7 @@ def test_translate_projects_json_object_dictionary_values():
             fallback => "{\"severity\":\"unknown\",\"action\":\"log\"}"
           }
         }
-        '''
+        """
     )
     state = parser.analyze()
 

--- a/tests/test_plugin_behavior.py
+++ b/tests/test_plugin_behavior.py
@@ -955,6 +955,7 @@ def test_secops_external_lookup_reports_dialect_disabled_not_unsupported():
     assert "plugin_dialect_disabled" in codes
     assert report["dialect_disabled_plugin_counts"] == {"elasticsearch": 1}
     assert report["totals"]["unsupported_plugins"] == 0
+    assert "lookup_result" not in parser.analyze().tokens
 
 
 def test_config_regex_with_quantifier_parses_as_single_value():

--- a/tests/test_plugin_behavior.py
+++ b/tests/test_plugin_behavior.py
@@ -545,7 +545,10 @@ def test_dialect_profile_controls_on_error_block_support():
     logstash = ReverseParser(code, dialect="logstash")
 
     assert "fallback" in secops.analyze().tokens
-    assert any("on_error" in item for item in logstash.analyze().unsupported)
+    assert any(
+        warning["code"] == "plugin_dialect_disabled" and warning.get("source_token") == "on_error"
+        for warning in logstash.analysis_summary()["structured_warnings"]
+    )
     assert logstash.compat_report()["dialect_profile"]["supports_on_error_blocks"] is False
 
 
@@ -703,6 +706,54 @@ def test_translate_projects_json_object_dictionary_values():
     assert "error_details.action" in state.tokens
 
 
+def test_translate_preserves_nested_json_list_values():
+    parser = ReverseParser(
+        r"""
+        filter {
+          translate {
+            field => "error_code"
+            destination => "error_details"
+            dictionary => {
+              "E1" => "{\"items\":[{\"code\":\"a\"},true]}"
+            }
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+
+    assert any(
+        source.kind == "object_literal" and source.expression == '[["code", "a"]]'
+        for lineage in state.tokens["error_details.items"]
+        for source in lineage.sources
+    )
+
+
+def test_spec_ignored_keys_are_used_for_generic_config_warnings():
+    parser = ReverseParser(
+        r"""
+        filter {
+          translate {
+            field => "event_code"
+            destination => "event_action"
+            dictionary => { "100" => "login" }
+            mysterious => true
+          }
+        }
+        """
+    )
+    warnings = parser.analysis_summary()["structured_warnings"]
+
+    assert any(
+        warning["code"] == "unknown_config_key" and warning.get("source_token") == "mysterious" for warning in warnings
+    )
+    assert not any(
+        warning["code"] == "unknown_config_key"
+        and warning.get("source_token") in {"field", "destination", "dictionary"}
+        for warning in warnings
+    )
+
+
 def test_date_records_timezone_locale_and_dynamic_target_warning():
     parser = ReverseParser(
         r"""
@@ -724,6 +775,22 @@ def test_date_records_timezone_locale_and_dynamic_target_warning():
     assert "dynamic_date_timezone" in warnings
     assert "timezone(%{tz})" in lineage.transformations[0]
     assert "locale(en-US)" in lineage.transformations[0]
+
+
+def test_date_ignores_non_string_locale_in_transform():
+    parser = ReverseParser(
+        r"""
+        filter {
+          date {
+            match => ["event_time", "ISO8601"]
+            locale => ["en-US"]
+          }
+        }
+        """
+    )
+    lineage = parser.analyze().tokens["event.idm.read_only_udm.metadata.event_timestamp"][0]
+
+    assert "locale(" not in lineage.transformations[0]
 
 
 def test_ruby_models_set_remove_cancel_yield_and_globals_conservatively():
@@ -752,6 +819,27 @@ def test_ruby_models_set_remove_cancel_yield_and_globals_conservatively():
     assert "ruby_event_cancel" in codes
     assert "ruby_event_split" in codes
     assert "ruby_concurrency_risk" in codes
+
+
+def test_ruby_bracket_reads_ignore_write_lhs_and_allow_spacing():
+    parser = ReverseParser(
+        r"""
+        filter {
+          ruby {
+            code => "
+              event [ 'dst' ] = event.get 'src'
+              event.set 'other', event [ 'src2' ]
+              event.remove 'old'
+            "
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+
+    assert {source.path for source in state.tokens["dst"][0].sources} == {"src", "src2"}
+    assert {source.path for source in state.tokens["other"][0].sources} == {"src", "src2"}
+    assert "old" not in state.tokens
 
 
 def test_aggregate_models_map_state_and_timeout_tags():
@@ -824,6 +912,43 @@ def test_lookup_and_enrichment_plugins_project_known_targets():
     assert "event.idm.read_only_udm.target.ip" in state.tokens
     assert "ua_details.name" in state.tokens
     assert "geo.country_name" in state.tokens
+
+
+def test_enrichment_prefix_projects_without_dot_container():
+    parser = ReverseParser(
+        r"""
+        filter {
+          useragent {
+            source => "ua"
+            prefix => "ua_"
+            fields => ["name"]
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+
+    assert "ua_name" in state.tokens
+    assert "ua_.name" not in state.tokens
+
+
+def test_secops_external_lookup_reports_dialect_disabled_not_unsupported():
+    parser = ReverseParser(
+        r"""
+        filter {
+          elasticsearch {
+            query => "id:%{lookup_id}"
+            target => "lookup_result"
+          }
+        }
+        """
+    )
+    report = parser.compat_report()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert "plugin_dialect_disabled" in codes
+    assert report["dialect_disabled_plugin_counts"] == {"elasticsearch": 1}
+    assert report["totals"]["unsupported_plugins"] == 0
 
 
 def test_config_regex_with_quantifier_parses_as_single_value():

--- a/tests/test_plugin_behavior.py
+++ b/tests/test_plugin_behavior.py
@@ -497,6 +497,335 @@ def test_bare_xpath_key_with_equal_is_not_stripped_as_comment():
     assert not result.unsupported
 
 
+def test_dialect_defaults_control_mutate_order():
+    code = r"""
+    filter {
+      mutate {
+        replace => { "source" => "value" }
+        rename => { "source" => "target" }
+      }
+    }
+    """
+
+    secops_state = ReverseParser(code).analyze()
+    logstash_state = ReverseParser(code, dialect="logstash").analyze()
+
+    assert "target" in secops_state.tokens
+    assert logstash_state.tokens["target"][0].status == "unresolved"
+    assert "source" in logstash_state.tokens
+
+
+def test_mutate_order_override_beats_dialect_default():
+    code = r"""
+    filter {
+      mutate {
+        replace => { "source" => "value" }
+        rename => { "source" => "target" }
+      }
+    }
+    """
+
+    source_order = ReverseParser(code, dialect="logstash", mutate_canonical_order=False).analyze()
+    canonical = ReverseParser(code, dialect="secops", mutate_canonical_order=True).analyze()
+
+    assert "target" in source_order.tokens
+    assert canonical.tokens["target"][0].status == "unresolved"
+
+
+def test_dialect_profile_controls_on_error_block_support():
+    code = r"""
+    filter {
+      mutate { replace => { "source" => "value" } }
+      on_error {
+        mutate { replace => { "fallback" => "yes" } }
+      }
+    }
+    """
+    secops = ReverseParser(code, dialect="secops")
+    logstash = ReverseParser(code, dialect="logstash")
+
+    assert "fallback" in secops.analyze().tokens
+    assert any("on_error" in item for item in logstash.analyze().unsupported)
+    assert logstash.compat_report()["dialect_profile"]["supports_on_error_blocks"] is False
+
+
+def test_default_failure_tags_are_possible_not_definite():
+    parser = ReverseParser(
+        r"""
+        filter {
+          grok { match => { "message" => "%{IP:src_ip}" } }
+          if "_grokparsefailure" in [tags] {
+            mutate { replace => { "route" => "fallback" } }
+          }
+        }
+        """,
+        dialect="logstash"
+    )
+    state = parser.analyze()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert "_grokparsefailure" in state.tag_state.possibly
+    assert "_grokparsefailure" not in state.tag_state.definitely
+    assert "conditional_tag_check" in codes
+    assert "unreachable_branch" not in codes
+
+
+def test_empty_failure_tags_suppress_default_failure_route():
+    parser = ReverseParser(
+        r"""
+        filter {
+          grok {
+            match => { "message" => "%{IP:src_ip}" }
+            tag_on_failure => []
+          }
+          if "_grokparsefailure" in [tags] {
+            mutate { replace => { "route" => "fallback" } }
+          }
+        }
+        """,
+        dialect="logstash"
+    )
+    state = parser.analyze()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert "_grokparsefailure" not in state.tag_state.possibly
+    assert "unreachable_branch" in codes
+
+
+def test_custom_failure_tags_and_on_error_are_possible_tags():
+    parser = ReverseParser(
+        r"""
+        filter {
+          json {
+            source => "message"
+            tag_on_failure => ["custom_json_fail"]
+            on_error => "json_on_error"
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+
+    assert "custom_json_fail" in state.tag_state.possibly
+    assert "json_on_error" in state.tag_state.possibly
+    assert "custom_json_fail" not in state.tag_state.definitely
+    assert "json_on_error" in state.tokens
+
+
+def test_known_common_plugin_options_do_not_warn_as_unknown():
+    parser = ReverseParser(
+        r"""
+        filter {
+          json {
+            source => "message"
+            id => "json-1"
+            enable_metric => false
+            tag_on_failure => ["json_fail"]
+            add_field => { "decorated" => "yes" }
+          }
+        }
+        """
+    )
+    summary = parser.analysis_summary()
+
+    assert not any(
+        warning["code"] == "unknown_config_key"
+        and warning.get("source_token") in {"id", "enable_metric", "tag_on_failure", "add_field"}
+        for warning in summary["structured_warnings"]
+    )
+    assert "decorated" in parser.analyze().tokens
+
+
+def test_translate_inline_dictionary_records_derived_mapping():
+    parser = ReverseParser(
+        r"""
+        filter {
+          translate {
+            field => "event_code"
+            destination => "event_action"
+            dictionary => {
+              "100" => "login"
+              "200" => "logout"
+            }
+            fallback => "unknown"
+          }
+        }
+        """
+    )
+    lineages = parser.analyze().tokens["event_action"]
+
+    assert lineages[0].status == "derived"
+    assert "translate_dictionary" in lineages[0].transformations
+    assert "translate_fallback" in lineages[0].transformations
+    assert lineages[0].sources[0].path == "event_code"
+    assert any("login" in note for note in lineages[0].notes)
+
+
+def test_translate_regex_and_dictionary_path_stay_dynamic_with_warning():
+    parser = ReverseParser(
+        r"""
+        filter {
+          translate {
+            field => "ua"
+            destination => "ua_class"
+            dictionary_path => "/tmp/ua.yml"
+            regex => true
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert state.tokens["ua_class"][0].status == "dynamic"
+    assert "translate_regex" in state.tokens["ua_class"][0].transformations
+    assert "dynamic_translate_dictionary" in codes
+
+
+def test_translate_projects_json_object_dictionary_values():
+    parser = ReverseParser(
+        r'''
+        filter {
+          translate {
+            field => "error_code"
+            destination => "error_details"
+            dictionary => {
+              "E1" => "{\"severity\":\"high\",\"action\":\"block\"}"
+            }
+            fallback => "{\"severity\":\"unknown\",\"action\":\"log\"}"
+          }
+        }
+        '''
+    )
+    state = parser.analyze()
+
+    assert "error_details.severity" in state.tokens
+    assert "error_details.action" in state.tokens
+
+
+def test_date_records_timezone_locale_and_dynamic_target_warning():
+    parser = ReverseParser(
+        r"""
+        filter {
+          date {
+            match => ["event_time", "ISO8601", "UNIX_MS"]
+            target => "event.idm.read_only_udm.metadata.%{dynamic_timestamp}"
+            timezone => "%{tz}"
+            locale => "en-US"
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+    warnings = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+    lineage = state.tokens["event.idm.read_only_udm.metadata.%{dynamic_timestamp}"][0]
+
+    assert "dynamic_date_target" in warnings
+    assert "dynamic_date_timezone" in warnings
+    assert "timezone(%{tz})" in lineage.transformations[0]
+    assert "locale(en-US)" in lineage.transformations[0]
+
+
+def test_ruby_models_set_remove_cancel_yield_and_globals_conservatively():
+    parser = ReverseParser(
+        r"""
+        filter {
+          ruby {
+            code => "
+              $seen = true
+              event.set('derived_field', event.get('source_field'))
+              event.remove('old_field')
+              new_event_block.call(event.clone)
+              event.cancel
+            "
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert state.tokens["derived_field"][0].status == "dynamic"
+    assert state.tokens["derived_field"][0].sources[0].path == "source_field"
+    assert "ruby_set" in state.tokens["derived_field"][0].transformations
+    assert "noop_remove_field" in codes
+    assert "ruby_event_cancel" in codes
+    assert "ruby_event_split" in codes
+    assert "ruby_concurrency_risk" in codes
+
+
+def test_aggregate_models_map_state_and_timeout_tags():
+    parser = ReverseParser(
+        r"""
+        filter {
+          aggregate {
+            task_id => "%{session_id}"
+            code => "map['first_seen'] = event.get('@timestamp'); event.set('seen_at', map['first_seen'])"
+            timeout_tags => ["_aggregate_timeout"]
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+    codes = {warning["code"] for warning in parser.analysis_summary()["structured_warnings"]}
+
+    assert "@metadata.aggregate.first_seen" in state.tokens
+    assert "seen_at" in state.tokens
+    assert state.tokens["seen_at"][0].sources[0].kind in {"aggregate_get", "aggregate_map"}
+    assert "_aggregate_timeout" in state.tag_state.possibly
+    assert state.failure_tag_routes[0].plugin == "aggregate"
+    assert "aggregate_state" in codes
+
+
+def test_aggregate_timeout_flush_projects_map_keys():
+    parser = ReverseParser(
+        r"""
+        filter {
+          aggregate {
+            task_id => "%{session_id}"
+            code => "map['events_count'] ||= 0"
+            push_map_as_event_on_timeout => true
+          }
+        }
+        """
+    )
+    state = parser.analyze()
+
+    assert "events_count" in state.tokens
+    assert "aggregate_timeout_flush" in state.tokens["events_count"][0].transformations
+
+
+def test_lookup_and_enrichment_plugins_project_known_targets():
+    parser = ReverseParser(
+        r"""
+        filter {
+          elasticsearch {
+            query => "id:%{lookup_id}"
+            target => "lookup_result"
+            fields => { "ip" => "event.idm.read_only_udm.target.ip" }
+          }
+          useragent {
+            source => "ua"
+            target => "ua_details"
+            fields => ["name", "os"]
+          }
+          geoip {
+            source => "src_ip"
+            target => "geo"
+            fields => ["country_name"]
+          }
+        }
+        """,
+        dialect="logstash",
+    )
+    state = parser.analyze()
+
+    assert "lookup_result" in state.tokens
+    assert "event.idm.read_only_udm.target.ip" in state.tokens
+    assert "ua_details.name" in state.tokens
+    assert "geo.country_name" in state.tokens
+
+
 def test_config_regex_with_quantifier_parses_as_single_value():
     result = parse_config(r"match => /\d{1,3}\.\d{1,3}/")
     # Expect a single ('match', regex_value) tuple, not a parse error or split into atoms.

--- a/tests/test_plugin_behavior.py
+++ b/tests/test_plugin_behavior.py
@@ -829,6 +829,8 @@ def test_ruby_bracket_reads_ignore_write_lhs_and_allow_spacing():
             code => "
               event [ 'dst' ] = event.get 'src'
               event.set 'other', event [ 'src2' ]
+              event [ 'counter' ] ||= 0
+              event [ 'attempts' ] += 1
               event.remove 'old'
             "
           }
@@ -839,6 +841,8 @@ def test_ruby_bracket_reads_ignore_write_lhs_and_allow_spacing():
 
     assert {source.path for source in state.tokens["dst"][0].sources} == {"src", "src2"}
     assert {source.path for source in state.tokens["other"][0].sources} == {"src", "src2"}
+    assert "counter" in state.tokens
+    assert "attempts" in state.tokens
     assert "old" not in state.tokens
 
 
@@ -871,7 +875,7 @@ def test_aggregate_timeout_flush_projects_map_keys():
         filter {
           aggregate {
             task_id => "%{session_id}"
-            code => "map['events_count'] ||= 0"
+            code => "map['events_count'] ||= 0; map['first_seen'] = event.get('@timestamp')"
             push_map_as_event_on_timeout => true
           }
         }
@@ -881,6 +885,8 @@ def test_aggregate_timeout_flush_projects_map_keys():
 
     assert "events_count" in state.tokens
     assert "aggregate_timeout_flush" in state.tokens["events_count"][0].transformations
+    assert "first_seen" in state.tokens
+    assert "aggregate_timeout_flush" in state.tokens["first_seen"][0].transformations
 
 
 def test_lookup_and_enrichment_plugins_project_known_targets():

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -4,7 +4,7 @@ Coverage targets:
 * Registry: register / lookup / contains / merge / from_paths.
 * TOML loader: single file, directory, sorted-key determinism, default
   ``name`` from table key, validation error → ValueError mapping.
-* Bundled registry returns an empty registry (no signatures shipped in v0.2).
+* Bundled registry returns conservative audited signatures.
 * Pydantic ``extra="forbid"`` rejects unknown signature keys.
 * End-to-end dispatch: a registered fake plugin produces signature-dispatched
   lineage with the declared semantic_class / lineage_status / sources.
@@ -205,9 +205,8 @@ class TestTomlLoader:
         assert "ignored" not in reg
 
     def test_load_directory_silent_on_missing_path(self, tmp_path: Path) -> None:
-        # Non-directory paths are silently ignored — the bundled directory
-        # ships empty in v0.2 so callers can opt into "load if present"
-        # without guarding.
+        # Non-directory paths are silently ignored so callers can opt into
+        # "load if present" without guarding.
         reg = PluginSignatureRegistry()
         reg.load_directory(tmp_path / "does_not_exist")
         assert len(reg) == 0
@@ -434,9 +433,28 @@ class TestTomlLoader:
 
 
 class TestBundledRegistry:
-    def test_empty_in_v0_2(self) -> None:
+    def test_bundled_registry_loads_common_signatures(self) -> None:
         reg = load_bundled_registry()
-        assert len(reg) == 0
+        assert len(reg) > 0
+        assert "throttle" in reg
+        assert "threat_lookup" in reg
+
+    def test_bundled_signature_dispatch_replaces_unsupported_path(self) -> None:
+        from parser_lineage_analyzer.analyzer import ReverseParser
+
+        src = """\
+filter {
+  throttle {
+    key => "%{message}"
+    add_tag => ["throttled"]
+  }
+}
+"""
+        rp = ReverseParser(src, plugin_signatures=load_bundled_registry())
+        state = rp.analyze()
+
+        assert not state.unsupported
+        assert "throttled" in state.tag_state.possibly
 
 
 # -- Dispatch end-to-end ----------------------------------------------

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -118,7 +118,7 @@ def test_rename_normalizes_and_removes_source_descendants():
       mutate { merge => { "@output" => "event" } }
     }
     """
-    parent_state = ReverseParser(parent_code).analyze()
+    parent_state = ReverseParser(parent_code, dialect="logstash").analyze()
     assert not any(token == "old" or token.startswith("old.") for token in parent_state.tokens)
 
 

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -105,7 +105,7 @@ def test_rename_normalizes_and_removes_source_descendants():
       mutate { merge => { "@output" => "event" } }
     }
     """
-    rp = ReverseParser(code)
+    rp = ReverseParser(code, dialect="logstash")
     state = rp.analyze()
     assert "old.field" not in state.tokens
     assert "old.other" in state.tokens
@@ -277,7 +277,7 @@ def test_compact_unsupported_warning_catalog_covers_representative_codes():
     code = r"""
     filter {
       unsupported_custom_plugin { url => "https://example.invalid" }
-      mutate { strip => ["message"] }
+      mutate { weird_mutate => ["message"] }
       mutate { replace => { "event.idm.read_only_udm.additional.fields.%{runtime_key}" => "v" } }
       mutate { gsub => [ "message", "(foo)", "\1" ] }
       for a, b, c in ["x"] {
@@ -813,7 +813,7 @@ def test_external_lookup_target_and_get_collision_keeps_both_lineages():
       }
     }
     """
-    rp = ReverseParser(code)
+    rp = ReverseParser(code, dialect="logstash")
     lineages = rp.analyze().tokens.get("es.id", [])
     assert len(lineages) >= 2, lineages
     paths = sorted({src.path or "" for lin in lineages for src in lin.sources})

--- a/tests/test_runtime_fixture_check.py
+++ b/tests/test_runtime_fixture_check.py
@@ -28,3 +28,19 @@ def test_runtime_fixture_check_reports_missing_static_coverage(tmp_path, capsys)
     assert report["results"][0]["failures"]["missing_fields"] == ["missing"]
     assert runtime_fixture_check.main(["--root", str(tmp_path / "runtime")]) == 1
     assert "runtime fixture mismatch" in capsys.readouterr().err
+
+
+def test_runtime_fixture_check_honors_fixture_dialect(tmp_path):
+    fixture = tmp_path / "runtime" / "logstash"
+    fixture.mkdir(parents=True)
+    (fixture / "parser.cbn").write_text('filter { json { source => "message" } }\n', encoding="utf-8")
+    (fixture / "input.json").write_text('{"message":"not-json"}\n', encoding="utf-8")
+    (fixture / "expected.json").write_text(
+        json.dumps({"dialect": "logstash", "tags": ["_jsonparsefailure"]}),
+        encoding="utf-8",
+    )
+
+    report = runtime_fixture_check.check_runtime_fixtures(tmp_path / "runtime")
+
+    assert report["failed"] == 0
+    assert report["results"][0]["dialect"] == "logstash"

--- a/tests/test_runtime_fixture_check.py
+++ b/tests/test_runtime_fixture_check.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+
+from scripts import runtime_fixture_check
+
+
+def test_runtime_fixture_check_passes_checked_in_fixture():
+    report = runtime_fixture_check.check_runtime_fixtures(runtime_fixture_check.DEFAULT_ROOT)
+
+    assert report["fixture_count"] >= 1
+    assert report["failed"] == 0
+
+
+def test_runtime_fixture_check_reports_missing_static_coverage(tmp_path, capsys):
+    fixture = tmp_path / "runtime" / "bad"
+    fixture.mkdir(parents=True)
+    (fixture / "parser.cbn").write_text('filter { mutate { replace => { "seen" => "yes" } } }\n', encoding="utf-8")
+    (fixture / "input.json").write_text('{"message":"x"}\n', encoding="utf-8")
+    (fixture / "expected.json").write_text(
+        json.dumps({"touched_fields": ["missing"], "tags": ["missing_tag"], "output_anchors": ["event"]}),
+        encoding="utf-8",
+    )
+
+    report = runtime_fixture_check.check_runtime_fixtures(tmp_path / "runtime")
+
+    assert report["failed"] == 1
+    assert report["results"][0]["failures"]["missing_fields"] == ["missing"]
+    assert runtime_fixture_check.main(["--root", str(tmp_path / "runtime")]) == 1
+    assert "runtime fixture mismatch" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add dialect profiles and expanded plugin specs for SecOps and Logstash compatibility policy.
- Add compatibility reporting, corpus audit tooling, bundled conservative plugin signatures, and runtime fixture validation.
- Deepen semantic support for failure tags, date/translate/ruby/aggregate handling, lookup/enrichment plugins, and dialect-specific behavior.
- Preserve Gemini's follow-up tightening: SecOps keeps Google SecOps defaults, statedump terminal metadata, disabled default failure tags, and Logstash-only external lookup plugin support.

## Validation

- `ruff check parser_lineage_analyzer scripts tests/test_plugin_behavior.py tests/test_plugin_signatures.py tests/test_compat_audit_corpus.py tests/test_runtime_fixture_check.py tests/test_remediation.py`
- `mypy parser_lineage_analyzer`
- `git diff --check`
- `pytest` (`1645 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundled conservative plugin signatures now ship with the package, reducing unsupported plugin warnings for common enrichers.
  * Added `--compat-report` and `--dialect` CLI flags to generate compatibility reports and select parser dialect (secops/logstash).
  * Added `--mutate-source-order` flag for alternative mutate operation ordering.
  * Support for `strip` mutate operation now enabled.
  * New auditing and validation tools: corpus compatibility auditing and runtime fixture checking.

* **Improvements**
  * Enhanced configuration validation and ignored-key handling.
  * Improved timezone and locale support in date transformations.
  * Better field projection for enrichment and lookup plugins.
  * Refined failure tag routing and error diagnostics.

* **Documentation**
  * Updated plugin signature loading documentation to reflect bundled signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->