### PR TITLE
[codex] Improve analyzer correctness and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,33 +103,40 @@ cat examples/example_parser.cbn | parser-lineage-analyzer - target.ip
 parser-lineage-analyzer PARSER_FILE [UDM_FIELD] [flags]
 ```
 
-`UDM_FIELD` is required for query mode and omitted for `--list` /
-`--summary`. Flags may appear in any position.
+`UDM_FIELD` is required for query mode and omitted for `--list`,
+`--summary`, `--compact-summary`, and `--compat-report`. Flags may appear
+in any position.
 
 | Flag | Purpose |
 |---|---|
 | `--json` | Machine-readable JSON output. |
 | `--list` | List discovered UDM-like parser fields instead of querying. |
 | `--summary` | Emit parser/analyzer coverage summary. |
+| `--compat-report` | Emit a dialect-oriented compatibility report for unsupported plugins, unknown config keys, dynamic features, failure-tag routes, and affected fields. |
 | `--compact-json` | Bound query JSON for high-cardinality output; samples large arrays, preserves `*_total` counters. |
 | `--compact-summary` | Bound summary diagnostics; includes counts by code. Implies `--summary`. |
-| `--strict` | Exit `3` if any parser-level warning, taint, or unsupported construct is present, OR if the query-level result is unresolved/partial/dynamic. When combined with `--json`/`--compact-json` the same summary is also embedded under a top-level `strict_failure` key. |
+| `--strict` | Exit `3` if any parser-level warning, taint, or unsupported construct is present, OR if the query-level result is unresolved/partial/dynamic. Applies to query, list, and summary modes; cannot be used with `--compat-report`. When combined with `--json`/`--compact-json` the same summary is also embedded under a top-level `strict_failure` key. |
 | `--verbose` | Include parser locations, notes, taints, and structured warnings in text output. |
+| `--dialect {secops,logstash}` | Parser compatibility profile. Defaults to `secops`; `logstash` mode defaults mutate blocks to Logstash's canonical operation order. |
 | `--max-parser-bytes N` | Cap input size in bytes (default `25000000`; `-1` for unlimited). |
-| `--mutate-canonical-order` | Reorder ops within each `mutate{}` block into Logstash's canonical execution order. Default is source order. |
+| `--mutate-canonical-order` | Force Logstash's canonical operation order within each `mutate{}` block. `secops` defaults to source order; `logstash` defaults to canonical order. |
+| `--mutate-source-order` | Force source-order mutate execution, overriding the dialect default. Mutually exclusive with `--mutate-canonical-order`. |
 | `--include-pattern-bodies` | Include the resolved grok regex body in JSON `details`. Off by default to keep `jq` output readable; `resolved_pattern_name` is always emitted. In `--verbose` text mode the body is shown unconditionally. |
 | `--grok-patterns-dir DIR` | Add a directory (or single file) of grok pattern definitions to the bundled Logstash legacy library. Repeatable; later entries override earlier ones. |
 | `--plugin-signatures FILE` | Load plugin signatures from a TOML file. Repeatable; later files override earlier ones. |
 | `--plugin-signatures-dir DIR` | Load every `*.toml` file in DIR as plugin signatures (non-recursive). Repeatable; processed before individual `--plugin-signatures` files. |
 | `--version` | Print the package version and exit. |
 
-Output is plain ASCII; if color is added in a future release, `NO_COLOR`
-will be honored.
+Text output preserves Unicode parser values and scrubs terminal control
+characters. JSON output is ASCII-escaped by `json.dumps`. If color is added
+in a future release, `NO_COLOR` will be honored.
 
-`--json` always emits `output_anchors`, `unsupported`, `warnings`,
-`structured_warnings`, and `diagnostics` — as `[]` when empty — so
-downstream consumers can rely on a stable key set. `*_total` counters are
-emitted only by `--compact-json` and remain omitted from plain `--json`.
+For query, list, and summary output, `--json` emits `output_anchors`,
+`unsupported`, `warnings`, `structured_warnings`, and `diagnostics` — as
+`[]` when empty — so downstream consumers can rely on a stable key set.
+Compatibility reports (`--compat-report --json`) have their own JSON schema.
+`*_total` counters are emitted only by `--compact-json` and remain omitted
+from plain query `--json`.
 
 ### Exit codes
 

--- a/parser_lineage_analyzer/_analysis_flow.py
+++ b/parser_lineage_analyzer/_analysis_flow.py
@@ -8,7 +8,11 @@ from collections.abc import Callable, Iterable
 from functools import lru_cache
 from typing import Protocol, cast
 
-from ._analysis_condition_facts import condition_is_contradicted, is_exact_literal_regex_condition
+from ._analysis_condition_facts import (
+    condition_is_contradicted,
+    conditions_are_compatible,
+    is_exact_literal_regex_condition,
+)
 from ._analysis_details import iterable_sources_details, loop_tuple_details
 from ._analysis_diagnostics import (
     config_parse_warning,
@@ -60,12 +64,15 @@ MAX_CLONE_FANOUT = 128
 
 # Phase 3B: detect `"<lit>" in [tags]` so the analyzer can flag branches
 # that check for a tag no prior add_tag could have written.
-_TAGS_MEMBERSHIP_RE = re.compile(r'^"(?P<lit>[^"]+)"\s+in\s+\[tags\]$')
+_TAGS_MEMBERSHIP_RE = re.compile(r'^(?:"(?P<dlit>(?:\\.|[^"\\])*)"|\'(?P<slit>(?:\\.|[^\'\\])*)\')\s+in\s+\[tags\]$')
 
 # R1.3: detect `"<lit>" in [<field>]` for any field (not just `tags`).
 # When `<field>`'s lineage carries `value_type="string"`, this is substring
 # matching, not array membership — emit an advisory so users notice.
-_GENERIC_IN_CHECK_RE = re.compile(r'^"(?P<lit>[^"]+)"\s+in\s+\[(?P<field>[A-Za-z_@][A-Za-z0-9_@.:-]*)\]$')
+_GENERIC_IN_CHECK_RE = re.compile(
+    r'^(?:"(?P<dlit>(?:\\.|[^"\\])*)"|\'(?P<slit>(?:\\.|[^\'\\])*)\')'
+    r"\s+in\s+\[(?P<field>[A-Za-z_@][A-Za-z0-9_@.:-]*)\]$"
+)
 MAX_ELIF_CHAIN_BEFORE_WARNING = 1_000
 MAX_ARRAY_LITERAL_BEFORE_WARNING = 100_000
 _PluginHandler = Callable[[Plugin, AnalyzerState, list[str]], None]
@@ -83,6 +90,38 @@ _REGEX_LITERAL_IN_CONDITION_RE = re.compile(r"=~\s*/((?:\\.|[^/\\])*)/[A-Za-z]*"
 # preceding the brace, since `on_error => "tag"` (the canonical failure-tag
 # form) is fine.
 _ON_ERROR_BLOCK_IN_CONFIG_RE = re.compile(r"\bon_error\s*\{")
+
+
+def _decode_condition_literal(value: str, delimiter: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value):
+            escaped = value[i + 1]
+            decoded = {
+                "n": "\n",
+                "t": "\t",
+                "r": "\r",
+                "f": "\f",
+                "b": "\b",
+                "v": "\v",
+                "\\": "\\",
+            }.get(escaped)
+            if decoded is None and escaped == delimiter:
+                decoded = delimiter
+            out.append(decoded if decoded is not None else "\\" + escaped)
+            i += 2
+            continue
+        out.append(value[i])
+        i += 1
+    return "".join(out)
+
+
+def _membership_literal(match: re.Match[str]) -> str:
+    double_value = match.group("dlit")
+    if double_value is not None:
+        return _decode_condition_literal(double_value, '"')
+    return _decode_condition_literal(match.group("slit") or "", "'")
 
 
 def _iter_regex_over_escapes(condition: str) -> Iterable[tuple[str, str]]:
@@ -357,32 +396,46 @@ class FlowExecutorMixin:
                 # approach in `_exec_if` (see `_prior_negation_conditions`).
                 cond = _clean_condition(child.condition)
                 prior_negations: list[str] = []
-                self._exec_io_block(
-                    IOBlock(line=child.line, kind=stmt.kind, body=child.then_body),
-                    state,
-                    _dedupe_strings(conditions + _prior_negation_conditions(prior_negations) + [cond]),
-                    depth,
-                    loop_fanout,
-                )
+                then_base_conditions = _dedupe_strings(conditions + _prior_negation_conditions(prior_negations))
+                then_conditions = _dedupe_strings(then_base_conditions + [cond])
+                if self._branch_is_reachable(cond, then_base_conditions, child.line, state):
+                    self._exec_io_block(
+                        IOBlock(line=child.line, kind=stmt.kind, body=child.then_body),
+                        state,
+                        then_conditions,
+                        depth,
+                        loop_fanout,
+                    )
                 prior_negations.append(f"NOT({cond})")
                 for elif_block in child.elifs:
                     ec = _clean_condition(elif_block.condition)
-                    self._exec_io_block(
-                        IOBlock(line=elif_block.line, kind=stmt.kind, body=elif_block.body),
-                        state,
-                        _dedupe_strings(conditions + _prior_negation_conditions(prior_negations) + [ec]),
-                        depth,
-                        loop_fanout,
-                    )
+                    elif_negations = _prior_negation_conditions(prior_negations)
+                    elif_base_conditions = _dedupe_strings(conditions + elif_negations)
+                    elif_conditions = _dedupe_strings(elif_base_conditions + [ec])
+                    if not self._tag_negation_conditions_are_unreachable(
+                        elif_negations, state
+                    ) and self._branch_is_reachable(ec, elif_base_conditions, elif_block.line, state):
+                        self._exec_io_block(
+                            IOBlock(line=elif_block.line, kind=stmt.kind, body=elif_block.body),
+                            state,
+                            elif_conditions,
+                            depth,
+                            loop_fanout,
+                        )
                     prior_negations.append(f"NOT({ec})")
                 if child.else_body is not None:
-                    self._exec_io_block(
-                        IOBlock(line=child.line, kind=stmt.kind, body=child.else_body),
-                        state,
-                        _dedupe_strings(conditions + _prior_negation_conditions(prior_negations)),
-                        depth,
-                        loop_fanout,
-                    )
+                    else_negations = _prior_negation_conditions(prior_negations)
+                    else_conditions = _dedupe_strings(conditions + else_negations)
+                    if conditions_are_compatible(
+                        else_conditions, tuple(state.implicit_path_conditions)
+                    ) and not self._tag_negation_conditions_are_unreachable(else_negations, state):
+                        self._exec_io_block(
+                            IOBlock(line=child.line, kind=stmt.kind, body=child.else_body),
+                            state,
+                            else_conditions,
+                            depth,
+                            loop_fanout,
+                        )
             elif isinstance(child, ForBlock):
                 # T3.1: real Logstash configs occasionally enumerate sinks via
                 # a for-loop (e.g. ``output { for x in [...] { http { url => "%{x}" } } }``).
@@ -491,9 +544,12 @@ class FlowExecutorMixin:
             ec = _clean_condition(elif_cond)
             self._warn_condition_limits(ec, _line, state)
             self._sync_branch_seed_diagnostics(original, state)
-            elif_base_conditions = _dedupe_strings(conditions + _prior_negation_conditions(prior_negations))
+            elif_negations = _prior_negation_conditions(prior_negations)
+            elif_base_conditions = _dedupe_strings(conditions + elif_negations)
             elif_conditions = _dedupe_strings(elif_base_conditions + [ec])
-            if self._branch_is_reachable(ec, elif_base_conditions, _line, state):
+            if not self._tag_negation_conditions_are_unreachable(elif_negations, state) and self._branch_is_reachable(
+                ec, elif_base_conditions, _line, state
+            ):
                 elif_state = original.clone()
                 self._exec_statements(body, elif_state, elif_conditions, depth, loop_fanout)
                 branch_records.append(BranchRecord(elif_state, elif_conditions, False))
@@ -503,9 +559,11 @@ class FlowExecutorMixin:
 
         if stmt.else_body is not None:
             else_state = original.clone()
-            else_conditions = _dedupe_strings(conditions + _prior_negation_conditions(prior_negations))
-            self._exec_statements(stmt.else_body, else_state, else_conditions, depth, loop_fanout)
-            branch_records.append(BranchRecord(else_state, else_conditions, False))
+            else_negations = _prior_negation_conditions(prior_negations)
+            else_conditions = _dedupe_strings(conditions + else_negations)
+            if not self._tag_negation_conditions_are_unreachable(else_negations, state):
+                self._exec_statements(stmt.else_body, else_state, else_conditions, depth, loop_fanout)
+                branch_records.append(BranchRecord(else_state, else_conditions, False))
         else:
             # No-op path: fields can retain their original lineage.
             #
@@ -793,7 +851,7 @@ class FlowExecutorMixin:
         match = _TAGS_MEMBERSHIP_RE.match(cond.strip())
         if not match:
             return
-        literal = match.group("lit")
+        literal = _membership_literal(match)
         tag_state = state.tag_state
         if tag_state.definitely or tag_state.possibly or tag_state.has_dynamic:
             if literal in tag_state.definitely:
@@ -848,6 +906,36 @@ class FlowExecutorMixin:
             source_token=literal,
         )
 
+    def _tag_negation_conditions_are_unreachable(self, conditions: list[str], state: AnalyzerState) -> bool:
+        """Return True when an else condition negates a definitely-true tag check."""
+        for condition in conditions:
+            if not condition.startswith("NOT(") or not condition.endswith(")"):
+                continue
+            inner = condition[4:-1]
+            if self._tag_membership_check_is_definitely_true(inner, state):
+                return True
+        return False
+
+    def _tag_membership_check_is_definitely_true(self, cond: str, state: AnalyzerState) -> bool:
+        match = _TAGS_MEMBERSHIP_RE.match(cond.strip())
+        if not match:
+            return False
+        literal = _membership_literal(match)
+        tag_state = state.tag_state
+        if tag_state.definitely or tag_state.possibly or tag_state.has_dynamic:
+            return not tag_state.has_dynamic and literal in tag_state.definitely
+        tag_lineages = state.tokens.get("tags", [])
+        if not tag_lineages:
+            return False
+        has_remove_anywhere = any("remove_tag" in lineage.transformations for lineage in tag_lineages)
+        if has_remove_anywhere:
+            return False
+        return any(
+            not lineage.conditions
+            and any(source.kind == "constant" and (source.expression or "") == literal for source in lineage.sources)
+            for lineage in tag_lineages
+        )
+
     def _tag_membership_check_is_unreachable(self, cond: str, state: AnalyzerState) -> bool:
         """Recognize ``"<lit>" in [tags]`` and check whether any prior
         add_tag could have added the literal.
@@ -860,7 +948,7 @@ class FlowExecutorMixin:
         match = _TAGS_MEMBERSHIP_RE.match(cond.strip())
         if not match:
             return False
-        literal = match.group("lit")
+        literal = _membership_literal(match)
         tag_state = state.tag_state
         if tag_state.definitely or tag_state.possibly or tag_state.has_dynamic:
             if tag_state.has_dynamic:

--- a/parser_lineage_analyzer/cli.py
+++ b/parser_lineage_analyzer/cli.py
@@ -71,7 +71,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help=(
             "Exit 3 if any parser-level (warning, taint, unsupported construct) "
             "or query-level (unresolved, partial, dynamic) finding is present. "
-            "Applies to --list, --summary, --compact-summary, and query modes."
+            "Applies to --list, --summary, --compact-summary, and query modes. "
+            "Cannot be used with --compat-report."
         ),
     )
     parser.add_argument(
@@ -112,8 +113,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Reorder operations within each mutate{} block into Logstash's "
-            "canonical execution order before iterating. Default is source "
-            "order; this flag opts into Logstash-fidelity semantics."
+            "canonical execution order before iterating. Secops defaults to "
+            "source order; logstash defaults to canonical order. This flag "
+            "forces Logstash-fidelity semantics."
         ),
     )
     parser.add_argument(

--- a/parser_lineage_analyzer/config_parser.py
+++ b/parser_lineage_analyzer/config_parser.py
@@ -116,7 +116,7 @@ def _line_column(text: str, pos: int) -> tuple[int, int]:
 
 
 def _line_offset(text: str, line_one_indexed: int) -> int:
-    """Return byte offset of the start of the given 1-indexed line."""
+    """Return character offset of the start of the given 1-indexed line."""
     pos = 0
     for _ in range(line_one_indexed - 1):
         nl = text.find("\n", pos)

--- a/scripts/benchmark_native_modes.py
+++ b/scripts/benchmark_native_modes.py
@@ -11,7 +11,7 @@ import sys
 import textwrap
 import time
 from collections.abc import Callable, Sequence
-from typing import Protocol, cast
+from typing import NamedTuple, Protocol, cast
 
 NATIVE_ENV_FLAGS = (
     "PARSER_LINEAGE_ANALYZER_NO_EXT",
@@ -39,6 +39,12 @@ class _CompletedProcessLike(Protocol):
 
 class _Runner(Protocol):
     def __call__(self, command: list[str], *, env: dict[str, str], timeout: float | None) -> _CompletedProcessLike: ...
+
+
+class ModeResult(NamedTuple):
+    name: str
+    elapsed: float
+    failed: int
 
 
 BENCHMARK_DRIVER = r"""
@@ -102,7 +108,7 @@ def _run_mode(
     timeout_seconds: float | None,
     runner: _Runner,
     clock: Callable[[], float],
-) -> int:
+) -> ModeResult:
     env = dict(os.environ)
     for flag in NATIVE_ENV_FLAGS:
         env.pop(flag, None)
@@ -117,7 +123,7 @@ def _run_mode(
         timeout_label = "unknown" if timeout_seconds is None else f"{timeout_seconds:.3f}s"
         print(f"mode={name} exit=timeout elapsed={elapsed:.3f}s")
         print(f"mode={name} timed out after {timeout_label}", file=sys.stderr)
-        return 1
+        return ModeResult(name, elapsed, 1)
     elapsed = clock() - start
     print(f"mode={name} exit={result.returncode} elapsed={elapsed:.3f}s")
     failed = result.returncode
@@ -127,7 +133,22 @@ def _run_mode(
             file=sys.stderr,
         )
         failed = 1
-    return 1 if failed else 0
+    return ModeResult(name, elapsed, 1 if failed else 0)
+
+
+def _mode_ratio_lines(
+    results: Sequence[ModeResult],
+    *,
+    baseline_name: str = "default-native",
+) -> list[str]:
+    baseline = next((result.elapsed for result in results if result.name == baseline_name), None)
+    if baseline is None or baseline <= 0:
+        return []
+    lines = [f"\nmode elapsed ratios (baseline={baseline_name}):"]
+    for result in results:
+        ratio = result.elapsed / baseline
+        lines.append(f"  {result.name:24s} elapsed={result.elapsed:8.3f}s ratio={ratio:6.2f}x")
+    return lines
 
 
 def main(
@@ -142,6 +163,7 @@ def main(
     mode_budget_seconds = _budget_from_env(MODE_BUDGET_ENV, DEFAULT_MODE_BUDGET_SECONDS)
     total_budget_seconds = _budget_from_env(TOTAL_BUDGET_ENV, DEFAULT_TOTAL_BUDGET_SECONDS)
     failures = 0
+    results: list[ModeResult] = []
     start = clock()
     for name, updates in modes:
         elapsed_so_far = clock() - start
@@ -151,7 +173,7 @@ def main(
         if total_budget_seconds >= 0:
             timeout_candidates.append(max(0.0, total_budget_seconds - elapsed_so_far))
         timeout_seconds = min(timeout_candidates) if timeout_candidates else None
-        failures |= _run_mode(
+        result = _run_mode(
             name,
             updates,
             benchmark_driver=benchmark_driver,
@@ -160,8 +182,12 @@ def main(
             runner=runner,
             clock=clock,
         )
+        results.append(result)
+        failures |= result.failed
     elapsed = clock() - start
     print(f"\nbenchmark total elapsed={elapsed:.3f}s budget={total_budget_seconds:.3f}s")
+    for line in _mode_ratio_lines(results):
+        print(line)
     if total_budget_seconds >= 0 and elapsed > total_budget_seconds:
         print(
             f"benchmark total exceeded budget: {elapsed:.3f}s > {total_budget_seconds:.3f}s",

--- a/scripts/compat_audit_corpus.py
+++ b/scripts/compat_audit_corpus.py
@@ -6,15 +6,56 @@ import argparse
 import json
 import sys
 from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Literal, TypedDict, cast
 
 from parser_lineage_analyzer import ReverseParser
 from parser_lineage_analyzer._plugin_signatures import PluginSignatureRegistry, load_bundled_registry
+from parser_lineage_analyzer._types import JSONDict, JSONValue
+
+Dialect = Literal["secops", "logstash"]
+CountSectionKey = Literal[
+    "unsupported_plugin_counts",
+    "unsupported_mutate_operation_counts",
+    "unknown_config_key_counts",
+    "warning_counts",
+    "top_affected_fields",
+]
+
+
+class AuditEntry(TypedDict):
+    path: str
+    report: JSONDict
+
+
+class DialectTotals(TypedDict):
+    parser_count: int
+    totals: dict[str, int]
+    unsupported_plugin_counts: dict[str, int]
+    unsupported_mutate_operation_counts: dict[str, int]
+    unknown_config_key_counts: dict[str, int]
+    warning_counts: dict[str, int]
+    top_affected_fields: dict[str, int]
+
+
+class PluginSignatureSummary(TypedDict):
+    enabled: bool
+    count: int
+
+
+class AuditReport(TypedDict):
+    root: str
+    dialects: list[Dialect]
+    plugin_signatures: PluginSignatureSummary
+    parser_count: int
+    totals_by_dialect: dict[Dialect, DialectTotals]
+    reports_by_dialect: dict[Dialect, list[AuditEntry]]
+
 
 DEFAULT_ROOT = Path("tests/fixtures/test_corpus")
 DEFAULT_OUT_DIR = Path("build/compat-audit")
-DEFAULT_DIALECTS = ("secops", "logstash")
+DEFAULT_DIALECTS: tuple[Dialect, ...] = ("secops", "logstash")
 REGRESSION_TOTAL_KEYS = (
     "unsupported_plugins",
     "unsupported_mutate_operations",
@@ -28,15 +69,15 @@ def iter_parser_files(root: Path) -> list[Path]:
 
 
 def audit_corpus(
-    root: Path, dialects: list[str], plugin_signatures: PluginSignatureRegistry | None = None
-) -> dict[str, Any]:
+    root: Path, dialects: list[Dialect], plugin_signatures: PluginSignatureRegistry | None = None
+) -> AuditReport:
     root = root.resolve()
     parser_files = iter_parser_files(root)
-    reports_by_dialect: dict[str, list[dict[str, Any]]] = {}
-    totals_by_dialect: dict[str, dict[str, Any]] = {}
+    reports_by_dialect: dict[Dialect, list[AuditEntry]] = {}
+    totals_by_dialect: dict[Dialect, DialectTotals] = {}
 
     for dialect in dialects:
-        reports: list[dict[str, Any]] = []
+        reports: list[AuditEntry] = []
         unsupported_plugins: Counter[str] = Counter()
         unsupported_mutate_ops: Counter[str] = Counter()
         unknown_config_keys: Counter[str] = Counter()
@@ -46,6 +87,7 @@ def audit_corpus(
 
         for path in parser_files:
             rel_path = path.relative_to(root).as_posix()
+            report: JSONDict
             try:
                 code = path.read_text(encoding="utf-8-sig")
                 report = ReverseParser(code, dialect=dialect, plugin_signatures=plugin_signatures).compat_report(
@@ -70,8 +112,8 @@ def audit_corpus(
                     "affected_field_counts": {},
                 }
             reports.append({"path": rel_path, "report": report})
-            report_totals = report.get("totals", {})
-            if isinstance(report_totals, dict):
+            report_totals = report.get("totals")
+            if isinstance(report_totals, Mapping):
                 for key, value in report_totals.items():
                     if isinstance(value, int):
                         totals[key] += value
@@ -105,9 +147,9 @@ def audit_corpus(
     }
 
 
-def _counter_from_report(report: dict[str, Any], key: str) -> Counter[str]:
-    raw = report.get(key, {})
-    if not isinstance(raw, dict):
+def _counter_from_report(report: Mapping[str, JSONValue], key: str) -> Counter[str]:
+    raw = report.get(key)
+    if not isinstance(raw, Mapping):
         return Counter()
     out: Counter[str] = Counter()
     for item, count in raw.items():
@@ -120,7 +162,7 @@ def _top_counts(counter: Counter[str], limit: int = 25) -> dict[str, int]:
     return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit])
 
 
-def render_markdown(audit: dict[str, Any]) -> str:
+def render_markdown(audit: AuditReport) -> str:
     lines = [
         "# Parser Compatibility Audit",
         "",
@@ -145,13 +187,14 @@ def render_markdown(audit: dict[str, Any]) -> str:
         for key in sorted(totals):
             lines.append(f"| {key} | {totals[key]} |")
         lines.append("")
-        for heading, key in (
+        sections: tuple[tuple[str, CountSectionKey], ...] = (
             ("Unsupported Plugins", "unsupported_plugin_counts"),
             ("Unsupported Mutate Ops", "unsupported_mutate_operation_counts"),
             ("Unknown Config Keys", "unknown_config_key_counts"),
             ("Warning Counts", "warning_counts"),
             ("Top Affected Fields", "top_affected_fields"),
-        ):
+        )
+        for heading, key in sections:
             lines.extend(_markdown_counts(heading, dialect_totals[key]))
     return "\n".join(lines).rstrip() + "\n"
 
@@ -167,35 +210,37 @@ def _markdown_counts(heading: str, counts: dict[str, int]) -> list[str]:
     return lines
 
 
-def regression_messages(current: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+def regression_messages(current: AuditReport, baseline: Mapping[str, JSONValue]) -> list[str]:
     messages: list[str] = []
-    current_totals = current.get("totals_by_dialect", {})
-    baseline_totals = baseline.get("totals_by_dialect", {})
-    if not isinstance(current_totals, dict) or not isinstance(baseline_totals, dict):
+    current_totals = current["totals_by_dialect"]
+    baseline_totals = baseline.get("totals_by_dialect")
+    if not isinstance(baseline_totals, Mapping):
         return ["baseline/current audit shape is invalid"]
     for dialect in sorted(current_totals):
-        if isinstance(dialect, str) and dialect not in baseline_totals:
+        if dialect not in baseline_totals:
             messages.append(f"{dialect}: missing baseline dialect")
-    for dialect, baseline_payload in baseline_totals.items():
-        if not isinstance(dialect, str) or not isinstance(baseline_payload, dict):
+    for baseline_dialect, baseline_payload in baseline_totals.items():
+        if not isinstance(baseline_dialect, str) or not isinstance(baseline_payload, Mapping):
             continue
-        current_payload = current_totals.get(dialect)
-        if not isinstance(current_payload, dict):
-            messages.append(f"{dialect}: missing current dialect")
+        current_payload = (
+            current_totals.get(cast(Dialect, baseline_dialect)) if baseline_dialect in DEFAULT_DIALECTS else None
+        )
+        if current_payload is None:
+            messages.append(f"{baseline_dialect}: missing current dialect")
             continue
-        baseline_counts = baseline_payload.get("totals", {})
-        current_counts = current_payload.get("totals", {})
-        if not isinstance(baseline_counts, dict) or not isinstance(current_counts, dict):
+        baseline_counts = baseline_payload.get("totals")
+        current_counts = current_payload["totals"]
+        if not isinstance(baseline_counts, Mapping):
             continue
         for key in REGRESSION_TOTAL_KEYS:
             old = baseline_counts.get(key, 0)
             new = current_counts.get(key, 0)
             if isinstance(old, int) and isinstance(new, int) and new > old:
-                messages.append(f"{dialect}: {key} regressed from {old} to {new}")
+                messages.append(f"{baseline_dialect}: {key} regressed from {old} to {new}")
     return messages
 
 
-def write_outputs(audit: dict[str, Any], json_out: Path, md_out: Path) -> None:
+def write_outputs(audit: AuditReport, json_out: Path, md_out: Path) -> None:
     json_out.parent.mkdir(parents=True, exist_ok=True)
     md_out.parent.mkdir(parents=True, exist_ok=True)
     json_out.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -223,9 +268,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _dedupe_dialects(raw: list[Dialect] | None) -> list[Dialect]:
+    return list(dict.fromkeys(raw or list(DEFAULT_DIALECTS)))
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
-    dialects = list(dict.fromkeys(args.dialect or list(DEFAULT_DIALECTS)))
+    dialects = _dedupe_dialects(cast(list[Dialect] | None, args.dialect))
     json_out = args.json_out or (args.out_dir / "compat-audit.json")
     md_out = args.md_out or (args.out_dir / "compat-audit.md")
 
@@ -234,7 +283,7 @@ def main(argv: list[str] | None = None) -> int:
     write_outputs(audit, json_out, md_out)
 
     if args.fail_on_regression:
-        baseline = json.loads(args.fail_on_regression.read_text(encoding="utf-8"))
+        baseline = cast(JSONDict, json.loads(args.fail_on_regression.read_text(encoding="utf-8")))
         messages = regression_messages(audit, baseline)
         if messages:
             for message in messages:

--- a/scripts/runtime_fixture_check.py
+++ b/scripts/runtime_fixture_check.py
@@ -17,25 +17,61 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import TypedDict
 
 from parser_lineage_analyzer import ReverseParser
 from parser_lineage_analyzer._analysis_state import AnalyzerState
 from parser_lineage_analyzer._plugin_specs import normalize_dialect
+from parser_lineage_analyzer._types import JSONValue
+from parser_lineage_analyzer.model import Lineage
 
 DEFAULT_ROOT = Path("tests/fixtures/runtime")
+
+
+class _FixtureFailures(TypedDict):
+    missing_fields: list[str]
+    missing_tags: list[str]
+    missing_output_anchors: list[str]
+
+
+class _FixtureExpected(TypedDict):
+    touched_fields: list[str]
+    tags: list[str]
+    output_anchors: list[str]
+
+
+class _FixtureReport(TypedDict):
+    fixture: str
+    parser: str
+    input: str | None
+    dialect: str
+    passed: bool
+    expected: _FixtureExpected
+    failures: _FixtureFailures
+
+
+class _RuntimeReport(TypedDict):
+    root: str
+    fixture_count: int
+    passed: int
+    failed: int
+    results: list[_FixtureReport]
 
 
 def discover_fixtures(root: Path) -> list[Path]:
     return sorted(path.parent for path in root.rglob("expected.json") if (path.parent / "parser.cbn").is_file())
 
 
-def check_fixture(fixture_dir: Path) -> dict[str, Any]:
+def check_fixture(fixture_dir: Path) -> _FixtureReport:
     parser_path = fixture_dir / "parser.cbn"
     input_path = fixture_dir / "input.json"
     expected_path = fixture_dir / "expected.json"
-    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    expected_value: JSONValue = json.loads(expected_path.read_text(encoding="utf-8"))
+    if not isinstance(expected_value, dict):
+        raise ValueError(f"{expected_path} must be a JSON object")
+    expected: Mapping[str, JSONValue] = expected_value
     code = parser_path.read_text(encoding="utf-8")
     dialect = normalize_dialect(str(expected.get("dialect", "secops")))
     parser = ReverseParser(code, dialect=dialect)
@@ -51,28 +87,29 @@ def check_fixture(fixture_dir: Path) -> dict[str, Any]:
     anchors = {anchor.anchor for anchor in state.output_anchors}
     missing_anchors = [anchor for anchor in expected_anchors if anchor not in anchors]
 
-    failures = {
+    failures: _FixtureFailures = {
         "missing_fields": missing_fields,
         "missing_tags": missing_tags,
         "missing_output_anchors": missing_anchors,
     }
     failed = any(failures.values())
+    expected_report: _FixtureExpected = {
+        "touched_fields": expected_fields,
+        "tags": expected_tags,
+        "output_anchors": expected_anchors,
+    }
     return {
         "fixture": fixture_dir.name,
         "parser": parser_path.as_posix(),
         "input": input_path.as_posix() if input_path.exists() else None,
         "dialect": dialect,
         "passed": not failed,
-        "expected": {
-            "touched_fields": expected_fields,
-            "tags": expected_tags,
-            "output_anchors": expected_anchors,
-        },
+        "expected": expected_report,
         "failures": failures,
     }
 
 
-def check_runtime_fixtures(root: Path) -> dict[str, Any]:
+def check_runtime_fixtures(root: Path) -> _RuntimeReport:
     root = root.resolve()
     results = [check_fixture(fixture_dir) for fixture_dir in discover_fixtures(root)]
     failed = [result for result in results if not result["passed"]]
@@ -85,7 +122,7 @@ def check_runtime_fixtures(root: Path) -> dict[str, Any]:
     }
 
 
-def _string_list(expected: dict[str, Any], key: str) -> list[str]:
+def _string_list(expected: Mapping[str, JSONValue], key: str) -> list[str]:
     value = expected.get(key, [])
     if not isinstance(value, list):
         raise ValueError(f"{key} must be a list")
@@ -93,9 +130,14 @@ def _string_list(expected: dict[str, Any], key: str) -> list[str]:
 
 
 def _field_is_covered(parser: ReverseParser, state: AnalyzerState, field: str) -> bool:
-    if field in state.tokens:
+    if _has_live_lineage(state.tokens.get(field, [])):
         return True
-    return bool(parser.query(field, compact=True).mappings)
+    result = parser.query(field, compact=True)
+    return _has_live_lineage(result.mappings)
+
+
+def _has_live_lineage(lineages: list[Lineage]) -> bool:
+    return any(lineage.status not in {"removed", "unresolved"} for lineage in lineages)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:

--- a/tests/fixtures/test_corpus/baseline/test_baseline_complex_interpolation.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_complex_interpolation.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_resolve_fields": ["new_field"],
   "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_conditional_tags_routing.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_conditional_tags_routing.expected.json
@@ -1,4 +1,4 @@
 {
-  "must_have_warning_codes": ["drop"],
+  "must_have_warning_codes": ["unreachable_branch"],
   "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/baseline/test_baseline_dns_resolution.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_baseline_dns_resolution.expected.json
@@ -1,8 +1,1 @@
-{
-  "must_resolve_fields": [
-    "source.hostname",
-    "source.ip",
-    "destination.ips",
-    "destination.domain"
-  ]
-}
+{}

--- a/tests/fixtures/test_corpus/baseline/test_trip_up_3_array_output_array_merge.expected.json
+++ b/tests/fixtures/test_corpus/baseline/test_trip_up_3_array_output_array_merge.expected.json
@@ -4,7 +4,6 @@
     "parse_recovery"
   ],
   "must_resolve_fields": [
-    "target.ip",
     "my_udm_object",
     "my_udm_object.child_key"
   ]

--- a/tests/fixtures/test_corpus/expected/test_cascading_datetime_fallbacks.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_cascading_datetime_fallbacks.expected.json
@@ -1,5 +1,5 @@
 {
   "must_have_warning_codes": ["conditional_tag_check"],
   "must_not_have_warning_codes": ["unknown_config_key"],
-  "must_resolve_fields": ["tags", "@timestamp"]
+  "must_resolve_fields": ["tags"]
 }

--- a/tests/fixtures/test_corpus/expected/test_complex_conditional_with_multiple_regex_captures.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_complex_conditional_with_multiple_regex_captures.expected.json
@@ -1,5 +1,4 @@
 {
   "must_have_warning_codes": ["mutate_ordering_drift", "runtime_condition"],
-  "must_not_have_warning_codes": ["malformed_config"],
-  "must_resolve_fields": ["activity", "username", "filename"]
+  "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/expected/test_complex_if_elsif_else_with_regex_captures_in_conditions.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_complex_if_elsif_else_with_regex_captures_in_conditions.expected.json
@@ -1,4 +1,4 @@
 {
   "must_have_warning_codes": ["drop", "runtime_condition"],
-  "must_resolve_fields": ["tags", "login_user"]
+  "must_resolve_fields": ["tags"]
 }

--- a/tests/fixtures/test_corpus/expected/test_conditional_regex_capture_multiple.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_conditional_regex_capture_multiple.expected.json
@@ -1,5 +1,4 @@
 {
   "must_have_warning_codes": ["runtime_condition"],
-  "must_not_have_warning_codes": ["malformed_config"],
-  "must_resolve_fields": ["extracted_name", "extracted_id"]
+  "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/expected/test_conditional_regex_with_capture_and_mutate.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_conditional_regex_with_capture_and_mutate.expected.json
@@ -1,5 +1,4 @@
 {
   "must_have_warning_codes": ["runtime_condition"],
-  "must_not_have_warning_codes": ["malformed_config"],
-  "must_resolve_fields": ["username", "domain"]
+  "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/expected/test_csv_dynamic_column_mapping.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_csv_dynamic_column_mapping.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_not_have_warning_codes": ["malformed_config"],
-  "must_resolve_fields": ["header[id]"]
+  "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/expected/test_csv_with_autogenerate_columns_and_rename.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_csv_with_autogenerate_columns_and_rename.expected.json
@@ -1,4 +1,3 @@
 {
-  "must_not_have_warning_codes": ["malformed_config"],
-  "must_resolve_fields": ["event_id", "event_type", "severity"]
+  "must_not_have_warning_codes": ["malformed_config"]
 }

--- a/tests/fixtures/test_corpus/expected/test_transform_handler_verification.expected.json
+++ b/tests/fixtures/test_corpus/expected/test_transform_handler_verification.expected.json
@@ -1,6 +1,1 @@
-{
-  "must_resolve_fields": [
-    "math_target",
-    "encrypted"
-  ]
-}
+{}

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -81,6 +81,46 @@ def test_native_modes_benchmark_fails_cleanly_when_runner_times_out(monkeypatch,
     assert "fake-mode timed out after 3.000s" in captured.err
 
 
+def test_native_modes_ratio_lines_compare_against_default_without_failing() -> None:
+    lines = benchmark_native_modes._mode_ratio_lines(
+        [
+            benchmark_native_modes.ModeResult("default-native", 10.0, 0),
+            benchmark_native_modes.ModeResult("no-ext", 12.5, 0),
+            benchmark_native_modes.ModeResult("no-native-dedupe", 8.0, 0),
+        ]
+    )
+
+    assert lines == [
+        "\nmode elapsed ratios (baseline=default-native):",
+        "  default-native           elapsed=  10.000s ratio=  1.00x",
+        "  no-ext                   elapsed=  12.500s ratio=  1.25x",
+        "  no-native-dedupe         elapsed=   8.000s ratio=  0.80x",
+    ]
+
+
+def test_native_modes_main_prints_ratio_report_when_default_mode_is_present(monkeypatch, capsys) -> None:
+    monkeypatch.setenv(benchmark_native_modes.MODE_BUDGET_ENV, "-1")
+    monkeypatch.setenv(benchmark_native_modes.TOTAL_BUDGET_ENV, "-1")
+    clock_values = iter([0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 5.0, 5.0])
+
+    def fake_runner(command, env, timeout):
+        assert timeout is None
+        return SimpleNamespace(returncode=0)
+
+    result = benchmark_native_modes.main(
+        modes=(("default-native", {}), ("no-ext", {"PARSER_LINEAGE_ANALYZER_NO_EXT": "1"})),
+        benchmark_driver="print('fake benchmark')",
+        runner=fake_runner,
+        clock=lambda: next(clock_values),
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "mode elapsed ratios (baseline=default-native):" in captured.out
+    assert "default-native           elapsed=   2.000s ratio=  1.00x" in captured.out
+    assert "no-ext                   elapsed=   3.000s ratio=  1.50x" in captured.out
+
+
 # Catastrophic-blowup watchdog for the grok pattern resolver. This file's
 # stated job is catching unintentional 10x slowdowns, NOT policing
 # percentile drift, so the budget is loose enough that runner noise on

--- a/tests/test_cli_and_public_model.py
+++ b/tests/test_cli_and_public_model.py
@@ -917,7 +917,10 @@ def test_cli_mutate_canonical_order_help_omits_internal_ticket(tmp_path):
     assert "--mutate-canonical-order" in help_text
     assert "T4.2" not in help_text
     # The behavior summary should still mention canonical order semantics.
-    assert "canonical" in help_text.lower()
+    flat = " ".join(help_text.split()).lower()
+    assert "canonical" in flat
+    assert "secops defaults to source order" in flat
+    assert "logstash defaults to canonical order" in flat
 
 
 def test_max_parser_bytes_constant_is_shared_with_analyzer():
@@ -968,6 +971,22 @@ def test_cli_text_output_scrubs_terminal_control_chars_in_warnings(tmp_path, cap
     out = capsys.readouterr().out
     assert "\x1b" not in out
     assert "\r" not in out
+
+
+def test_cli_text_output_preserves_unicode_values(tmp_path, capsys):
+    cafe = "caf" + chr(233)
+    code = f"""
+filter {{
+  mutate {{ replace => {{ "event.idm.read_only_udm.metadata.description" => "{cafe}" }} }}
+  mutate {{ merge => {{ "@output" => "event" }} }}
+}}
+"""
+    parser_file = _write_parser(tmp_path, code)
+
+    assert main([str(parser_file), "metadata.description"]) == 0
+    out = capsys.readouterr().out
+    assert f"expression: {cafe}" in out
+    assert f"constant:'{cafe}'" in out
 
 
 def test_io_anchor_is_publicly_exported():
@@ -1212,17 +1231,29 @@ def test_cli_strict_help_text_disambiguates_warning_levels():
     # query-level gates so users know which conditions trip exit 3.
     assert "parser-level" in flat
     assert "query-level" in flat
+    assert "cannot be used with --compat-report" in flat.lower()
 
 
 def test_readme_documents_new_cli_flags():
     readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
     for flag in (
+        "--compat-report",
+        "--dialect",
         "--grok-patterns-dir",
+        "--mutate-source-order",
         "--plugin-signatures",
         "--plugin-signatures-dir",
         "--include-pattern-bodies",
         "--version",
     ):
         assert flag in readme, f"README CLI flag table missing: {flag}"
+    assert "`--summary`, `--compact-summary`, and `--compat-report`" in readme
+    assert "cannot be used with `--compat-report`" in readme
+    assert "For query, list, and summary output, `--json` emits" in readme
+    assert "Compatibility reports (`--compat-report --json`) have their own JSON schema." in readme
+    assert "secops` defaults to source order" in readme
+    assert "logstash` defaults to canonical order" in readme
+    assert "Text output preserves Unicode parser values" in readme
+    assert "JSON output is ASCII-escaped" in readme
     assert "NO_COLOR" in readme
     assert "ASCII-aware only" in readme

--- a/tests/test_corpus_baseline.py
+++ b/tests/test_corpus_baseline.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
@@ -59,6 +60,7 @@ RECOVERY_AWARE_PHRASES = (
     "syntax error",
     "recovered parser",
 )
+Dialect = Literal["secops", "logstash"]
 
 
 def _smoke_fixture_paths() -> list[Path]:
@@ -76,7 +78,6 @@ def _fixture_id(path: Path) -> str:
 
 
 _FIXTURES = _smoke_fixture_paths()
-
 
 SIDECAR_KEYS = (
     "must_have_warning_codes",
@@ -113,18 +114,31 @@ def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, ob
         assert code not in warning_codes, f"{fixture_id}: warning code {code!r} should NOT be emitted but was"
     for field in expect_str_list(sidecar.get("must_resolve_fields", [])):
         result = parser.query(field)
-        assert result.mappings, f"{fixture_id}: query({field!r}) returned no mappings"
+        assert any(mapping.status not in {"removed", "unresolved"} for mapping in result.mappings), (
+            f"{fixture_id}: query({field!r}) returned no live mappings"
+        )
     for plugin in expect_str_list(sidecar.get("must_have_unsupported", [])):
         assert plugin in unsupported_blobs, (
             f"{fixture_id}: expected {plugin!r} in unsupported list; got {summary['unsupported']!r}"
         )
 
 
+def _sidecar_dialect(sidecar: dict[str, object] | None) -> Dialect:
+    if sidecar is None:
+        return "secops"
+    dialect = expect_str(sidecar.get("dialect", "secops"))
+    if dialect == "secops":
+        return "secops"
+    if dialect == "logstash":
+        return "logstash"
+    raise ValueError(f"sidecar dialect must be 'secops' or 'logstash', got {dialect!r}")
+
+
 @pytest.mark.parametrize("fixture_path", _FIXTURES, ids=[_fixture_id(p) for p in _FIXTURES])
 def test_corpus_fixture_analyzes_cleanly(fixture_path: Path) -> None:
     src = fixture_path.read_text(encoding="utf-8")
     sidecar = _sidecar_for(fixture_path)
-    dialect = expect_str(sidecar.get("dialect", "secops")) if sidecar is not None else "secops"
+    dialect = _sidecar_dialect(sidecar)
     start = time.perf_counter()
     parser = ReverseParser(src, dialect=dialect)
     parser.analyze()
@@ -164,6 +178,22 @@ def test_sidecar_loader_returns_none_for_missing_sidecar(tmp_path: Path) -> None
     fixture = tmp_path / "demo.cbn"
     fixture.write_text("filter {}", encoding="utf-8")
     assert _sidecar_for(fixture) is None
+
+
+def test_sidecar_must_resolve_fields_rejects_removed_only_mapping() -> None:
+    parser = ReverseParser(
+        """
+        filter {
+          mutate {
+            replace => { "gone" => "yes" }
+            remove_field => ["gone"]
+          }
+        }
+        """
+    )
+
+    with pytest.raises(AssertionError, match="no live mappings"):
+        _check_sidecar(parser, "demo.cbn", {"must_resolve_fields": ["gone"]})
 
 
 def test_corpus_buckets_have_expected_size() -> None:

--- a/tests/test_corpus_bugs.py
+++ b/tests/test_corpus_bugs.py
@@ -352,19 +352,11 @@ def test_bug_conditional_nested():
     condition (covered by test_bug_conditional_nested_contradiction)."""
     # fixture: test_conditional_nested
     parser = _load("test_conditional_nested.cbn")
-    parser.analyze()
-    # Lineage should record both nested conditions.
     state = parser.analyze()
-    found = False
-    for lineages in state.tokens.values():
-        for lin in lineages:
-            if any("[outer]" in c for c in lin.conditions) and any("[inner]" in c for c in lin.conditions):
-                found = True
-                break
-    # Either condition recording is present, or the fixture's tokens didn't
-    # land in state.tokens (depends on the exact assignments) — accept either
-    # without crashing.
-    assert isinstance(found, bool)
+    lineages = state.tokens.get("user.role", [])
+    assert lineages, "expected user.role assignment from nested-field condition fixture"
+    assert {lin.expression for lin in lineages} == {"Admin"}
+    assert all('[user][name] == "Alice"' in lin.conditions for lin in lineages)
 
 
 def test_bug_conditional_nested_contradiction():
@@ -736,6 +728,26 @@ def test_bug_tag_membership_with_matching_tag_stays_reachable():
     assert "unreachable_branch" not in _summary_codes(parser)
 
 
+def test_single_quoted_tag_membership_prunes_unreachable_branch():
+    """Single-quoted tag membership has the same runtime semantics as
+    double-quoted membership, so the analyzer must use the same reachability
+    pruning for both forms."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+          if 'missing' in [tags] {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "bad" } }
+          } else {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "ok" } }
+          }
+          mutate { merge => { "@output" => "event" } }
+        }
+    """)
+    result = parser.query("metadata.description")
+    assert {mapping.expression for mapping in result.mappings} == {"ok"}
+    assert "unreachable_branch" in _summary_codes(parser)
+
+
 def test_bug_conditional_or_disjunction_contradiction():
     """EASY-FIX (Phase 3D): the contradiction detector now considers
     OR-disjuncts. When every disjunct of an outer condition contradicts a
@@ -804,6 +816,282 @@ def test_bug_io_for_loop_routing():
     for anchor in es_anchors:
         keys = {k for k, _ in anchor.config_summary}
         assert "hosts" in keys and "index" in keys, anchor.config_summary
+
+
+def test_io_block_skips_unreachable_elif_anchor():
+    """Input/output routing should use the same branch reachability checks
+    as filter blocks; impossible elif branches must not produce IO anchors."""
+    parser = ReverseParser("""
+        output {
+          if [route] == "a" {
+            elasticsearch { hosts => ["hot"] index => "a" }
+          } else if [route] == "a" {
+            file { path => "/tmp/impossible" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert plugins == {"elasticsearch", "null"}
+    assert "unreachable_branch" in _summary_codes(parser)
+
+
+def test_io_block_skips_unreachable_single_quoted_tag_branch():
+    """Tag-membership pruning also applies inside output routing blocks."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+        }
+        output {
+          if 'missing' in [tags] {
+            file { path => "/tmp/missing" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert plugins == {"null"}
+    assert "unreachable_branch" in _summary_codes(parser)
+
+
+def test_tag_membership_preserves_unknown_escapes_like_config_strings():
+    """Unknown condition escapes must match config string decoding.
+
+    Config string decoding preserves unknown escapes (`\\q` stays `\\q`), so
+    the condition literal decoder must do the same. Otherwise this reachable
+    output route is mistaken for a missing tag and pruned as unreachable.
+    """
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["a\\q"] }
+        }
+        output {
+          if "a\\q" in [tags] {
+            file { path => "/tmp/matched" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "file" in plugins
+    assert "unreachable_branch" not in _summary_codes(parser)
+
+
+def test_tag_membership_decodes_known_quote_escape_like_config_strings():
+    """Known condition escapes must match config string decoding too.
+
+    The add_tag config string decodes `\"` to `"`, so the condition literal
+    must decode the same way or this reachable output route gets pruned.
+    """
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["a\\"b"] }
+        }
+        output {
+          if "a\\"b" in [tags] {
+            file { path => "/tmp/matched" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "file" in plugins
+    assert "unreachable_branch" not in _summary_codes(parser)
+
+
+def test_tag_membership_decodes_escaped_backslash_like_config_strings():
+    """Escaped backslashes in conditions must match config string decoding."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["a\\\\b"] }
+        }
+        output {
+          if "a\\\\b" in [tags] {
+            file { path => "/tmp/matched" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "file" in plugins
+    assert "unreachable_branch" not in _summary_codes(parser)
+
+
+def test_double_quoted_tag_membership_preserves_escaped_single_quote():
+    """Double-quoted condition literals preserve escaped single quotes."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["a\\'b"] }
+        }
+        output {
+          if "a\\'b" in [tags] {
+            file { path => "/tmp/matched" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "file" in plugins
+    assert "unreachable_branch" not in _summary_codes(parser)
+
+
+def test_single_quoted_tag_membership_preserves_escaped_double_quote():
+    """Single-quoted condition literals preserve escaped double quotes."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ['a\\"b'] }
+        }
+        output {
+          if 'a\\"b' in [tags] {
+            file { path => "/tmp/matched" }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "file" in plugins
+    assert "unreachable_branch" not in _summary_codes(parser)
+
+
+def test_io_block_skips_else_anchor_when_tag_check_is_definitely_true():
+    """A definitely-true tag membership check makes the synthesized else
+    negation unreachable, so the else output anchor should not survive.
+    """
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+        }
+        output {
+          if "seen" in [tags] {
+            elasticsearch { hosts => ["hot"] }
+          } else {
+            null { }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert plugins == {"elasticsearch"}
+
+
+def test_filter_if_skips_else_mapping_when_tag_check_is_definitely_true():
+    """Normal filter branches should prune an else branch whose synthesized
+    tag negation is unreachable.
+    """
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+          if "seen" in [tags] {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "then" } }
+          } else {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "else" } }
+          }
+          mutate { merge => { "@output" => "event" } }
+        }
+    """)
+    result = parser.query("metadata.description")
+    assert {mapping.expression for mapping in result.mappings} == {"then"}
+
+
+def test_filter_if_skips_elif_mapping_when_prior_tag_check_is_definitely_true():
+    """Normal filter elif branches should prune current-chain tag negations."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+          if "seen" in [tags] {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "then" } }
+          } else if [route] == "a" {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "bad" } }
+          }
+          mutate { merge => { "@output" => "event" } }
+        }
+    """)
+    result = parser.query("metadata.description")
+    assert {mapping.expression for mapping in result.mappings} == {"then"}
+
+
+def test_io_block_skips_elif_anchor_when_prior_tag_check_is_definitely_true():
+    """IO elif branches should prune current-chain tag negations."""
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+        }
+        output {
+          if "seen" in [tags] {
+            elasticsearch { hosts => ["hot"] }
+          } else if [route] == "a" {
+            file { path => "/tmp/bad" }
+          }
+        }
+    """)
+    state = parser.analyze()
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert plugins == {"elasticsearch"}
+
+
+def test_filter_if_inner_else_ignores_stale_outer_tag_negation_after_tag_mutation():
+    """Only the current if/elif chain's negations may prune an else branch."""
+    parser = ReverseParser("""
+        filter {
+          if "seen" in [tags] {
+            mutate { replace => { "event.idm.read_only_udm.metadata.description" => "outer then" } }
+          } else {
+            mutate { add_tag => ["seen"] }
+            if [route] == "a" {
+              mutate { replace => { "event.idm.read_only_udm.metadata.description" => "inner then" } }
+            } else {
+              mutate { replace => { "event.idm.read_only_udm.metadata.description" => "inner else" } }
+            }
+          }
+          mutate { merge => { "@output" => "event" } }
+        }
+    """)
+    result = parser.query("metadata.description")
+    assert "inner else" in {mapping.expression for mapping in result.mappings}
+
+
+def test_io_if_inner_else_ignores_stale_outer_tag_negation_after_tag_mutation():
+    """IO routing uses only the current if/elif chain's negations too."""
+    from parser_lineage_analyzer.ast_nodes import IfBlock, IOBlock, Plugin
+
+    parser = ReverseParser("""
+        filter {
+          mutate { add_tag => ["seen"] }
+        }
+    """)
+    state = parser.analyze()
+    parser._exec_io_block(
+        IOBlock(
+            line=1,
+            kind="output",
+            body=[
+                IfBlock(
+                    line=1,
+                    condition='[route] == "a"',
+                    then_body=[Plugin(line=1, name="elasticsearch", body="", config=[])],
+                    else_body=[Plugin(line=1, name="null", body="", config=[])],
+                )
+            ],
+        ),
+        state,
+        ['NOT("seen" in [tags])'],
+    )
+    plugins = {anchor.plugin for anchor in state.io_anchors}
+    assert "null" in plugins
 
 
 def test_bug_syslog_pri_resolves_concrete_labels_for_branched_pri():

--- a/tests/test_corpus_challenge.py
+++ b/tests/test_corpus_challenge.py
@@ -54,18 +54,21 @@ def _challenge_fixture_paths() -> list[Path]:
 _FIXTURES = _challenge_fixture_paths()
 
 
-def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, list[str]]) -> None:
+def _check_sidecar(parser: ReverseParser, fixture_id: str, sidecar: dict[str, object]) -> None:
     summary = parser.analysis_summary()
     warning_codes = {expect_str(expect_mapping(w)["code"]) for w in expect_mapping_list(summary["structured_warnings"])}
     unsupported_blob = " | ".join(expect_str_list(summary["unsupported"]))
 
-    for code in sidecar.get("must_have_warning_codes", []):
+    for code in expect_str_list(sidecar.get("must_have_warning_codes", [])):
         assert code in warning_codes, f"{fixture_id}: expected warning code {code!r}; got {sorted(warning_codes)}"
-    for code in sidecar.get("must_not_have_warning_codes", []):
+    for code in expect_str_list(sidecar.get("must_not_have_warning_codes", [])):
         assert code not in warning_codes, f"{fixture_id}: warning code {code!r} should NOT be emitted but was"
-    for field in sidecar.get("must_resolve_fields", []):
-        assert parser.query(field).mappings, f"{fixture_id}: query({field!r}) returned no mappings"
-    for plugin in sidecar.get("must_have_unsupported", []):
+    for field in expect_str_list(sidecar.get("must_resolve_fields", [])):
+        result = parser.query(field)
+        assert any(mapping.status not in {"removed", "unresolved"} for mapping in result.mappings), (
+            f"{fixture_id}: query({field!r}) returned no live mappings"
+        )
+    for plugin in expect_str_list(sidecar.get("must_have_unsupported", [])):
         assert plugin in unsupported_blob, (
             f"{fixture_id}: expected {plugin!r} in unsupported list; got {summary['unsupported']!r}"
         )
@@ -84,10 +87,36 @@ def test_challenge_fixture_completes_within_budget(fixture_path: Path) -> None:
 
     sidecar_path = fixture_path.with_suffix(".expected.json")
     if sidecar_path.exists():
-        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        sidecar_data = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        if not isinstance(sidecar_data, dict):
+            raise ValueError(f"{sidecar_path.name}: sidecar must be a JSON object")
+        sidecar: dict[str, object] = dict(sidecar_data)
         unknown = set(sidecar) - set(SIDECAR_KEYS)
         assert not unknown, f"{sidecar_path.name}: unknown sidecar keys {sorted(unknown)}"
         _check_sidecar(parser, fixture_path.name, sidecar)
+
+
+def test_challenge_sidecar_rejects_string_values_for_string_list_fields() -> None:
+    parser = ReverseParser("filter {}")
+
+    with pytest.raises(AssertionError, match="expected list"):
+        _check_sidecar(parser, "demo.cbn", {"must_not_have_warning_codes": "parse_recovery"})
+
+
+def test_challenge_sidecar_removed_field_is_not_live_resolution() -> None:
+    parser = ReverseParser(
+        """
+        filter {
+          mutate {
+            replace => { "gone" => "yes" }
+            remove_field => ["gone"]
+          }
+        }
+        """
+    )
+
+    with pytest.raises(AssertionError, match="no live mappings"):
+        _check_sidecar(parser, "demo.cbn", {"must_resolve_fields": ["gone"]})
 
 
 def test_challenge_bucket_size() -> None:

--- a/tests/test_grok_patterns.py
+++ b/tests/test_grok_patterns.py
@@ -16,6 +16,7 @@ Coverage targets:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -27,6 +28,7 @@ from parser_lineage_analyzer._grok_patterns import (
     expand_pattern,
     load_library_from_paths,
 )
+from parser_lineage_analyzer._types import ConfigPair, ConfigValue
 
 
 class TestBundledLibrary:
@@ -530,20 +532,19 @@ class TestPR11ReviewFixes:
         state = AnalyzerState()
         # ConfigPair tuples: (key, value). pattern_definitions value is
         # a list of (name, body) pairs. One good, one bad.
+        pattern_definitions: list[tuple[str, ConfigValue]] = [
+            ("GOOD_PAT", "[a-z]+"),
+            ("BAD_PAT", cast(ConfigValue, ["nested", "list"])),
+        ]
+        config: list[ConfigPair] = [
+            ("pattern_definitions", cast(ConfigValue, pattern_definitions)),
+            ("match", cast(ConfigValue, [("message", "%{BAD_PAT:weird} %{GOOD_PAT:good}")])),
+        ]
         plugin = Plugin(
             name="grok",
             body="",
             line=1,
-            config=[
-                (
-                    "pattern_definitions",
-                    [
-                        ("GOOD_PAT", "[a-z]+"),
-                        ("BAD_PAT", ["nested", "list"]),  # type: ignore[list-item]
-                    ],
-                ),
-                ("match", [("message", "%{BAD_PAT:weird} %{GOOD_PAT:good}")]),
-            ],
+            config=config,
         )
         rp._exec_grok(plugin, state, [])
         codes = {w.code for w in state.structured_warnings}

--- a/tests/test_implicit_path_conditions.py
+++ b/tests/test_implicit_path_conditions.py
@@ -266,22 +266,23 @@ class TestContradictionRouting:
         # Same body, opposite operators → must contradict via implicit-arg.
         body = r"^[a-z]+$"
         implicit = (f"[t] =~ /{body}/",)
-        assert condition_is_contradicted(f"[t] !~ /{body}/", (), implicit) is True
+        assert condition_is_contradicted(f"[t] !~ /{body}/", [], implicit) is True
         assert conditions_are_compatible([f"[t] !~ /{body}/"], implicit) is False
 
     def test_implicit_equivalent_to_prior_for_contradiction(self) -> None:
         body = r"^[a-z]+$"
         cond = f"[t] !~ /{body}/"
-        prior = (f"[t] =~ /{body}/",)
+        prior = [f"[t] =~ /{body}/"]
+        implicit = (f"[t] =~ /{body}/",)
         via_prior = condition_is_contradicted(cond, prior, ())
-        via_implicit = condition_is_contradicted(cond, (), prior)
+        via_implicit = condition_is_contradicted(cond, [], implicit)
         assert via_prior == via_implicit is True
 
     def test_implicit_default_empty_preserves_pre_pr_c_behavior(self) -> None:
         # Without implicit arg, behavior must be identical to PR-A baseline.
         cond = '[t] == "x"'
-        prior_only = condition_is_contradicted(cond, ('[t] != "x"',))
-        prior_with_explicit_empty_implicit = condition_is_contradicted(cond, ('[t] != "x"',), ())
+        prior_only = condition_is_contradicted(cond, ['[t] != "x"'])
+        prior_with_explicit_empty_implicit = condition_is_contradicted(cond, ['[t] != "x"'], ())
         assert prior_only is True
         assert prior_with_explicit_empty_implicit is True
 
@@ -368,7 +369,7 @@ class TestCrossFeatureWithF1NegMatch:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.user.userid")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # "123" is a valid INT value if grok1 matched; the if-branch must
         # remain reachable.
         assert "INT_LIT" in expressions, (
@@ -392,7 +393,7 @@ class TestCrossFeatureWithF1NegMatch:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         assert expressions == ["HTTPS", "OTHER"]
         assert "unreachable_branch" not in _summary_codes(parser)
 
@@ -441,7 +442,7 @@ class TestCrossFeatureWithF1NegMatch:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.user.userid")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # The if-branch is reachable: IPV6 grok overwrote ``tok``, the
         # stale INT constraint must have been dropped, and ``[tok] == "::1"``
         # is no longer flagged as a contradiction.
@@ -560,7 +561,7 @@ class TestMutatePropagation:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # Both branches must be reachable post-gsub — gsub could rewrite the
         # value to "abc"-compatible content (e.g. "abc" matches if every
         # digit is replaced with an X-prefixed letter run).
@@ -582,7 +583,7 @@ class TestMutatePropagation:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # ``replace`` overwrites with a literal; any prior INT constraint is
         # moot. Both branches stay reachable.
         assert "REACHABLE_AFTER_REPLACE" in expressions
@@ -610,7 +611,7 @@ class TestMutatePropagation:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         assert "MATCHED_APPENDED" in expressions, (
             f"add_field soundness regression: expected MATCHED_APPENDED to remain reachable, got {expressions!r}"
         )
@@ -631,7 +632,7 @@ class TestMutatePropagation:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         assert "REACHABLE_AFTER_CONVERT" in expressions
         assert "ELSE" in expressions
 
@@ -657,7 +658,7 @@ class TestMutatePropagation:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.user.userid")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # After rename, dst's value is the renamed src's value (INT-shape).
         # "123" is INT-compatible; the if-branch must remain reachable.
         # If the old UUID constraint on dst survived, "123" would be
@@ -758,7 +759,7 @@ class TestBranchMergeIntersection:
         parser = ReverseParser(code)
         parser.analyze()
         result = parser.query("principal.port")
-        expressions = sorted(m.expression for m in result.mappings)
+        expressions = sorted(expect_str(m.expression) for m in result.mappings)
         # Implicit constraint applies in both surviving branches → algebra
         # collapses the impossible-literal check post-merge.
         assert "POST_MERGE_UNREACHABLE" not in expressions
@@ -829,6 +830,7 @@ class TestCacheDiscipline:
         cache_info_after = _conditions_are_compatible_cached.cache_info()
         # currsize must not exceed maxsize. (A bug that mis-keys would
         # push currsize toward maxsize quickly.)
+        assert cache_info_after.maxsize is not None
         assert cache_info_after.currsize <= cache_info_after.maxsize
 
 

--- a/tests/test_plugin_signatures.py
+++ b/tests/test_plugin_signatures.py
@@ -908,8 +908,8 @@ filter {
         assert sig_lins
         upstream_token_names: set[str] = set()
         for lin in sig_lins:
-            for src in lin.sources:
-                upstream = src.details.get("upstream_sources") if src.details else None
+            for source_ref in lin.sources:
+                upstream = source_ref.details.get("upstream_sources") if source_ref.details else None
                 if not isinstance(upstream, (list, tuple)):
                     continue
                 for ref in upstream:

--- a/tests/test_runtime_fixture_check.py
+++ b/tests/test_runtime_fixture_check.py
@@ -30,6 +30,29 @@ def test_runtime_fixture_check_reports_missing_static_coverage(tmp_path, capsys)
     assert "runtime fixture mismatch" in capsys.readouterr().err
 
 
+def test_runtime_fixture_check_removed_field_is_not_live_coverage(tmp_path):
+    fixture = tmp_path / "runtime" / "removed"
+    fixture.mkdir(parents=True)
+    (fixture / "parser.cbn").write_text(
+        """
+        filter {
+          mutate {
+            replace => { "gone" => "yes" }
+            remove_field => ["gone"]
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    (fixture / "input.json").write_text('{"message":"x"}\n', encoding="utf-8")
+    (fixture / "expected.json").write_text(json.dumps({"touched_fields": ["gone"]}), encoding="utf-8")
+
+    report = runtime_fixture_check.check_runtime_fixtures(tmp_path / "runtime")
+
+    assert report["failed"] == 1
+    assert report["results"][0]["failures"]["missing_fields"] == ["gone"]
+
+
 def test_runtime_fixture_check_honors_fixture_dialect(tmp_path):
     fixture = tmp_path / "runtime" / "logstash"
     fixture.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- Fix tag-membership reachability for filter and IO `if` / `elif` / `else` branches, including single-quoted literals, delimiter-aware escapes, stale outer negations, and definitely true tag checks.
- Harden runtime, challenge, and baseline sidecar contracts so removed/unresolved mappings no longer count as live field resolution.
- Clean full-project mypy issues in scripts/tests, update stale corpus sidecars, and add focused regressions.
- Update CLI/README documentation for `--compat-report`, dialect mutate ordering, Unicode output, and `--strict` incompatibility.
- Add native benchmark elapsed ratio reporting without introducing brittle timing failures.

## Validation

- `.venv/bin/python -m ruff format --check .` passed.
- `.venv/bin/python -m ruff check .` passed.
- `.venv/bin/python -m mypy` passed: `Success: no issues found in 73 source files`.
- `.venv/bin/python -m pytest` passed: `1679 passed in 65.85s`.
- `.venv/bin/python setup.py sdist bdist_wheel` passed, with existing setuptools deprecation warnings.
- `.venv/bin/python -m bandit -c pyproject.toml -r parser_lineage_analyzer scripts -ll` passed: no issues.
- `.venv/bin/python scripts/benchmark_native_modes.py` passed: `54.291s / 240s` budget.
- `.venv/bin/python scripts/benchmark_native_targets.py` passed; clean rerun included `20k independent ifs median=3.347s`.

## Notes

`pip-audit` was attempted, but networked PyPI access was rejected by the escalation reviewer because it would disclose dependency metadata. No workaround was attempted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--compat-report` flag for compatibility auditing
  * Added `--dialect` option to select output mode (SecOps/Logstash) with dialect-specific defaults
  * Added `--mutate-source-order` flag for source-order field mutation execution

* **Improvements**
  * Enhanced tag membership parsing to support single and double-quoted literals with escape sequences
  * Refined control-flow reachability analysis for more accurate branch detection
  * Improved field resolution detection to distinguish active from removed fields
  * Updated text output to preserve Unicode; JSON output uses ASCII escaping

* **Documentation**
  * Updated CLI help documentation and README with new options and behavioral specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->